### PR TITLE
Unbounded message queue

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1041,4 +1041,35 @@ The externally maintained libraries used by Node.js are:
        on the database or the code.  Any person making a contribution to the
        database or code waives all rights to future claims in that
        contribution or in the TZ Database.
+
+- src/producer-consumer-queue.h. The folly::ProducerConsumerQueue class is a
+  one-producer one-consumer queue with very low synchronization overhead.
+  ProducerConsumerQueue's license follows:
+  """
+    Copyright 2015 Facebook, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Significant changes made to the software:
+
+    - Removed Boost dependency
+    - Removed support for storing values directly
+    - Removed construction and destruction of the queue items feature
+    - Added initialization of all values to nullptr
+    - Made size a template parameter
+    - Crash instead of throw if malloc fails in constructor
+    - Changed namespace from folly to node
+    - Removed sizeGuess(), isFull(), isEmpty(), popFront() and frontPtr() methods
+    - Renamed write() to PushBack(), read() to PopFront()
+    - Added padding to fields
   """

--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,12 @@ test-timers:
 test-timers-clean:
 	$(MAKE) --directory=tools clean
 
+test-workers: all
+	$(PYTHON) tools/test.py --mode=release workers -J
+
+test-workers-debug: all
+	$(PYTHON) tools/test.py --mode=debug workers -J
+
 apidoc_sources = $(wildcard doc/api/*.markdown)
 apidocs = $(addprefix out/,$(apidoc_sources:.markdown=.html)) \
 		$(addprefix out/,$(apidoc_sources:.markdown=.json))

--- a/common.gypi
+++ b/common.gypi
@@ -264,7 +264,7 @@
         'libraries': [ '-llog' ],
       }],
       ['OS=="mac"', {
-        'defines': ['_DARWIN_USE_64_BIT_INODE=1'],
+        'defines': ['_DARWIN_USE_64_BIT_INODE=1', 'NODE_OS_MACOSX'],
         'xcode_settings': {
           'ALWAYS_SEARCH_USER_PATHS': 'NO',
           'GCC_CW_ASM_SYNTAX': 'NO',                # No -fasm-blocks
@@ -275,7 +275,7 @@
           'GCC_ENABLE_PASCAL_STRINGS': 'NO',        # No -mpascal-strings
           'GCC_THREADSAFE_STATICS': 'NO',           # -fno-threadsafe-statics
           'PREBINDING': 'NO',                       # No -Wl,-prebind
-          'MACOSX_DEPLOYMENT_TARGET': '10.5',       # -mmacosx-version-min=10.5
+          'MACOSX_DEPLOYMENT_TARGET': '10.7',       # -mmacosx-version-min=10.7
           'USE_HEADERMAP': 'NO',
           'OTHER_CFLAGS': [
             '-fno-strict-aliasing',
@@ -302,7 +302,8 @@
           ['clang==1', {
             'xcode_settings': {
               'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0',
-              'CLANG_CXX_LANGUAGE_STANDARD': 'gnu++0x',  # -std=gnu++0x
+              'CLANG_CXX_LANGUAGE_STANDARD': 'c++11',  # -std=c++11
+              'CLANG_CXX_LIBRARY': 'libc++', #-stdlib=libc++
             },
           }],
         ],

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,0 +1,216 @@
+'use strict';
+
+if (!process.features.experimental_workers) {
+  throw new Error('Experimental workers are not enabled');
+}
+
+const util = require('util');
+const assert = require('assert');
+const EventEmitter = require('events');
+const WorkerContextBinding = process.binding('worker_context');
+const JSONStringify = function(value) {
+  if (value === undefined) value = null;
+  return JSON.stringify(value);
+};
+const JSONParse = JSON.parse;
+const EMPTY_ARRAY = [];
+
+const workerContextSymbol = Symbol('workerContext');
+const installEventsSymbol = Symbol('installEvents');
+const checkAliveSymbol = Symbol('checkAlive');
+const initSymbol = WorkerContextBinding.initSymbol;
+
+const builtinErrorTypes = new Map([
+  Error, SyntaxError, RangeError, URIError, TypeError, EvalError, ReferenceError
+].map(function(Type) {
+  return [Type.name, Type];
+}));
+
+const Worker = WorkerContextBinding.JsConstructor;
+util.inherits(Worker, EventEmitter);
+
+Worker.prototype[initSymbol] = function(entryModulePath, options) {
+  if (typeof entryModulePath !== 'string')
+    throw new TypeError('entryModulePath must be a string');
+  EventEmitter.call(this);
+  options = Object(options);
+  const keepAlive =
+      options.keepAlive === undefined ? true : !!options.keepAlive;
+  const evalCode = !!options.eval;
+  const userData = JSONStringify(options.data);
+  this[workerContextSymbol] =
+      new WorkerContextBinding.WorkerContext(entryModulePath, {
+        keepAlive: keepAlive,
+        userData: userData,
+        eval: evalCode
+      });
+  this[installEventsSymbol]();
+};
+
+Worker.prototype[installEventsSymbol] = function() {
+  const workerObject = this;
+  const workerContext = this[workerContextSymbol];
+
+  const onerror = function(payload) {
+    var ErrorConstructor = builtinErrorTypes.get(payload.builtinType);
+    if (typeof ErrorConstructor !== 'function')
+      ErrorConstructor = Error;
+    const error = new ErrorConstructor(payload.message);
+    error.stack = payload.stack;
+    util._extend(error, payload.additionalProperties);
+    workerObject.emit('error', error);
+  };
+
+  workerContext._onexit = function(exitCode) {
+    workerObject[workerContextSymbol] = null;
+    workerObject.emit('exit', exitCode);
+  };
+
+  workerContext._onmessage = function(payload, messageType) {
+    payload = JSONParse(payload);
+    switch (messageType) {
+      case WorkerContextBinding.USER:
+        return workerObject.emit('message', payload);
+      case WorkerContextBinding.EXCEPTION:
+        return onerror(payload);
+      default:
+        assert.fail('unreachable');
+    }
+  };
+};
+
+Worker.prototype[checkAliveSymbol] = function() {
+  if (!this[workerContextSymbol])
+    throw new RangeError('this worker has been terminated');
+};
+
+Worker.prototype.postMessage = function(payload) {
+  this[checkAliveSymbol]();
+  this[workerContextSymbol].postMessage(JSONStringify(payload),
+                                        EMPTY_ARRAY,
+                                        WorkerContextBinding.USER);
+};
+
+Worker.prototype.terminate = function(callback) {
+  this[checkAliveSymbol]();
+  const context = this[workerContextSymbol];
+  this[workerContextSymbol] = null;
+  if (typeof callback === 'function') {
+    this.once('exit', function(exitCode) {
+      callback(null, exitCode);
+    });
+  }
+  context.terminate();
+};
+
+Worker.prototype.ref = function() {
+  this[checkAliveSymbol]();
+  this[workerContextSymbol].ref();
+};
+
+Worker.prototype.unref = function() {
+  this[checkAliveSymbol]();
+  this[workerContextSymbol].unref();
+};
+
+if (process.isWorkerThread) {
+  const postMessage = function(payload, transferList, type) {
+    if (!Array.isArray(transferList))
+      throw new TypeError('transferList must be an array');
+
+    WorkerContextBinding.workerWrapper._postMessage(JSONStringify(payload),
+                                                    transferList,
+                                                    type);
+  };
+  const workerFatalError = function(er) {
+    const defaultStack = null;
+    const defaultMessage = '[toString() conversion failed]';
+    const defaultBuiltinType = 'Error';
+
+    var message = defaultMessage;
+    var builtinType = defaultBuiltinType;
+    var stack = defaultStack;
+    var additionalProperties = {};
+
+    // As this is a fatal error handler we cannot throw any new errors here
+    // but should still try to extract as much info as possible from the
+    // cause.
+    if (er instanceof Error) {
+      // .name can be a getter that throws.
+      try {
+        builtinType = er.name;
+      } catch (ignore) {}
+
+      if (typeof builtinType !== 'string')
+        builtinType = defaultBuiltinType;
+
+      // .stack can be a getter that throws.
+      try {
+        stack = er.stack;
+      } catch (ignore) {}
+
+      if (typeof stack !== 'string')
+        stack = defaultStack;
+
+      try {
+        // Get inherited enumerable properties.
+        // .name, .stack and .message are all non-enumerable
+        for (var key in er)
+          additionalProperties[key] = er[key];
+        // The message delivery must always succeed, otherwise the real cause
+        // of this fatal error is masked.
+        JSONStringify(additionalProperties);
+      } catch (e) {
+        additionalProperties = {};
+      }
+    }
+
+    try {
+      // .message can be a getter that throws or the call to toString may fail.
+      if (er instanceof Error) {
+        message = er.message;
+        if (typeof message !== 'string')
+          message = '' + er;
+      } else {
+        message = '' + er;
+      }
+    } catch (e) {
+      message = defaultMessage;
+    }
+
+    postMessage({
+      message: message,
+      stack: stack,
+      additionalProperties: additionalProperties,
+      builtinType: builtinType
+    }, EMPTY_ARRAY, WorkerContextBinding.EXCEPTION);
+  };
+
+  util._extend(Worker, EventEmitter.prototype);
+  EventEmitter.call(Worker);
+
+  WorkerContextBinding.workerWrapper._onmessage =
+      function(payload, messageType) {
+    payload = JSONParse(payload);
+    switch (messageType) {
+      case WorkerContextBinding.USER:
+        return Worker.emit('message', payload);
+      default:
+        assert.fail('unreachable');
+    }
+  };
+
+  Worker.postMessage = function(payload) {
+    postMessage(payload, EMPTY_ARRAY, WorkerContextBinding.USER);
+  };
+
+  Object.defineProperty(Worker, '_workerFatalError', {
+    configurable: true,
+    writable: false,
+    enumerable: false,
+    value: workerFatalError
+  });
+}
+
+
+module.exports = Worker;

--- a/node.gyp
+++ b/node.gyp
@@ -73,6 +73,7 @@
       'lib/internal/socket_list.js',
       'lib/internal/repl.js',
       'lib/internal/util.js',
+      'lib/worker.js'
     ],
   },
 
@@ -118,6 +119,8 @@
         'src/node_watchdog.cc',
         'src/node_zlib.cc',
         'src/node_i18n.cc',
+        'src/notification-channel.cc',
+        'src/persistent-handle-cleanup.cc',
         'src/pipe_wrap.cc',
         'src/signal_wrap.cc',
         'src/spawn_sync.cc',
@@ -130,6 +133,7 @@
         'src/process_wrap.cc',
         'src/udp_wrap.cc',
         'src/uv.cc',
+        'src/worker.cc',
         # headers to make for a more pleasant IDE experience
         'src/async-wrap.h',
         'src/async-wrap-inl.h',
@@ -143,6 +147,7 @@
         'src/node.h',
         'src/node_buffer.h',
         'src/node_constants.h',
+        'src/node-contextify.h',
         'src/node_file.h',
         'src/node_http_parser.h',
         'src/node_internals.h',
@@ -152,7 +157,10 @@
         'src/node_watchdog.h',
         'src/node_wrap.h',
         'src/node_i18n.h',
+        'src/notification-channel.h',
+        'src/persistent-handle-cleanup.h',
         'src/pipe_wrap.h',
+        'src/producer-consumer-queue.h',
         'src/tty_wrap.h',
         'src/tcp_wrap.h',
         'src/udp_wrap.h',
@@ -166,6 +174,7 @@
         'src/util.h',
         'src/util-inl.h',
         'src/util.cc',
+        'src/worker.h',
         'deps/http_parser/http_parser.h',
         'deps/v8/include/v8.h',
         'deps/v8/include/v8-debug.h',
@@ -184,6 +193,11 @@
         'V8_DEPRECATION_WARNINGS=1',
       ],
 
+      'xcode_settings': {
+          'OTHER_LDFLAGS': [
+            '-stdlib=libc++',
+          ],
+      },
 
       'conditions': [
         [ 'node_tag!=""', {
@@ -641,7 +655,8 @@
       'dependencies': [
         'deps/gtest/gtest.gyp:gtest',
         'deps/v8/tools/gyp/v8.gyp:v8',
-        'deps/v8/tools/gyp/v8.gyp:v8_libplatform'
+        'deps/v8/tools/gyp/v8.gyp:v8_libplatform',
+        'deps/uv/uv.gyp:libuv',
       ],
       'include_dirs': [
         'src',

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1239,13 +1239,19 @@ static void CaresTimerClose(Environment* env,
 }
 
 
+static void InitAresOnce() {
+  int r = ares_library_init(ARES_LIB_INIT_ALL);
+  CHECK_EQ(r, ARES_SUCCESS);
+}
+
+
 static void Initialize(Local<Object> target,
                        Local<Value> unused,
                        Local<Context> context) {
-  Environment* env = Environment::GetCurrent(context);
+  static uv_once_t init_once = UV_ONCE_INIT;
+  uv_once(&init_once, InitAresOnce);
 
-  int r = ares_library_init(ARES_LIB_INIT_ALL);
-  CHECK_EQ(r, ARES_SUCCESS);
+  Environment* env = Environment::GetCurrent(context);
 
   struct ares_options options;
   memset(&options, 0, sizeof(options));
@@ -1254,10 +1260,12 @@ static void Initialize(Local<Object> target,
   options.sock_state_cb_data = env;
 
   /* We do the call to ares_init_option for caller. */
-  r = ares_init_options(env->cares_channel_ptr(),
-                        &options,
-                        ARES_OPT_FLAGS | ARES_OPT_SOCK_STATE_CB);
+  int r = ares_init_options(env->cares_channel_ptr(),
+                            &options,
+                            ARES_OPT_FLAGS | ARES_OPT_SOCK_STATE_CB);
   CHECK_EQ(r, ARES_SUCCESS);
+  // Make env call ares_destroy when disposed.
+  env->set_using_cares();
 
   /* Initialize the timeout timer. The timer won't be started until the */
   /* first socket is opened. */

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -7,6 +7,7 @@
 #include "util-inl.h"
 #include "uv.h"
 #include "v8.h"
+#include "persistent-handle-cleanup.h"
 
 #include <stddef.h>
 #include <stdint.h>
@@ -43,6 +44,14 @@ inline Environment::IsolateData::IsolateData(v8::Isolate* isolate,
 #define V(PropertyName, StringValue)                                          \
     PropertyName ## _(isolate, FIXED_ONE_BYTE_STRING(isolate, StringValue)),
     PER_ISOLATE_STRING_PROPERTIES(V)
+#undef V
+
+#define V(PropertyName, StringName)                                           \
+    PropertyName ## _(isolate,                                                \
+                      v8::Symbol::New(isolate,                                \
+                                      FIXED_ONE_BYTE_STRING(isolate,          \
+                                                            StringName))),
+    PER_ISOLATE_SYMBOL_PROPERTIES(V)
 #undef V
     ref_count_(0) {}
 
@@ -132,8 +141,17 @@ inline void Environment::TickInfo::set_last_threw(bool value) {
 }
 
 inline Environment* Environment::New(v8::Local<v8::Context> context,
-                                     uv_loop_t* loop) {
-  Environment* env = new Environment(context, loop);
+                                     uv_loop_t* loop,
+                                     WorkerContext* worker_context) {
+  bool is_worker = worker_context != nullptr;
+  size_t thread_id = is_worker ? GenerateThreadId() : 0;
+  Environment* env = new Environment(context, loop, thread_id);
+  if (is_worker) {
+    env->set_worker_context(worker_context);
+    worker_context->set_worker_env(env);
+    env->set_owner_env(worker_context->owner_env());
+  }
+
   env->AssignToContext(context);
   return env;
 }
@@ -168,7 +186,8 @@ inline Environment* Environment::GetCurrent(
 }
 
 inline Environment::Environment(v8::Local<v8::Context> context,
-                                uv_loop_t* loop)
+                                uv_loop_t* loop,
+                                size_t thread_id)
     : isolate_(context->GetIsolate()),
       isolate_data_(IsolateData::GetOrCreate(context->GetIsolate(), loop)),
       timer_base_(uv_now(loop)),
@@ -178,6 +197,7 @@ inline Environment::Environment(v8::Local<v8::Context> context,
       printed_error_(false),
       trace_sync_io_(false),
       debugger_agent_(this),
+      thread_id_(thread_id),
       http_parser_buffer_(nullptr),
       context_(context->GetIsolate(), context) {
   // We'll be creating new objects so make sure we've entered the context.
@@ -191,7 +211,11 @@ inline Environment::Environment(v8::Local<v8::Context> context,
 }
 
 inline Environment::~Environment() {
+  CHECK_EQ(sub_worker_context_count(), 0);
   v8::HandleScope handle_scope(isolate());
+
+  PersistentHandleCleanup cleanup(this);
+  isolate()->VisitHandlesWithClassIds(&cleanup);
 
   context()->SetAlignedPointerInEmbedderData(kContextEmbedderDataIndex,
                                              nullptr);
@@ -202,6 +226,27 @@ inline Environment::~Environment() {
 
   delete[] heap_statistics_buffer_;
   delete[] http_parser_buffer_;
+
+  if (using_cares_) {
+    ares_destroy(ares_channel());
+    using_cares_ = false;
+  }
+
+  // For valgrind. The main environment cannot deal with CleanupHandles()
+  // for some reason.
+  while (HandleCleanup* hc = handle_cleanup_queue_.PopFront())
+    delete hc;
+}
+
+inline void Environment::TerminateSubWorkers() {
+  for (WorkerContext* context : *sub_worker_contexts()) {
+    // See libuv issue https://github.com/libuv/libuv/issues/276.
+    context->owner_notifications()->Ref();
+    context->Terminate(false);
+  }
+
+  while (sub_worker_context_count() > 0)
+    uv_run(event_loop(), UV_RUN_ONCE);
 }
 
 inline void Environment::CleanupHandles() {
@@ -264,10 +309,18 @@ inline uv_check_t* Environment::idle_check_handle() {
   return &idle_check_handle_;
 }
 
-inline void Environment::RegisterHandleCleanup(uv_handle_t* handle,
-                                               HandleCleanupCb cb,
-                                               void *arg) {
-  handle_cleanup_queue_.PushBack(new HandleCleanup(handle, cb, arg));
+inline void Environment::DeregisterHandleCleanup(HandleCleanup* hc) {
+  handle_cleanup_queue_.Remove(hc);
+  delete hc;
+}
+
+inline HandleCleanup* Environment::RegisterHandleCleanup(
+    uv_handle_t* handle,
+    HandleCleanupCb cb,
+    void* arg) {
+  HandleCleanup* hc = new HandleCleanup(handle, cb, arg);
+  handle_cleanup_queue_.PushBack(hc);
+  return hc;
 }
 
 inline void Environment::FinishHandleCleanup(uv_handle_t* handle) {
@@ -349,6 +402,45 @@ inline void Environment::set_http_parser_buffer(char* buffer) {
   http_parser_buffer_ = buffer;
 }
 
+inline WorkerContext* Environment::worker_context() const {
+  CHECK(is_worker_thread());
+  CHECK_NE(worker_context_, nullptr);
+  return worker_context_;
+}
+
+inline void Environment::set_worker_context(WorkerContext* context) {
+  CHECK_EQ(worker_context_, nullptr);
+  CHECK_NE(context, nullptr);
+  worker_context_ = context;
+}
+
+inline Environment* Environment::owner_env() const {
+  CHECK_NE(owner_env_, nullptr);
+  return owner_env_;
+}
+
+inline void Environment::set_owner_env(Environment* env) {
+  CHECK_EQ(owner_env_, nullptr);
+  CHECK_NE(env, nullptr);
+  owner_env_ = env;
+}
+
+inline size_t Environment::thread_id() const {
+  return thread_id_;
+}
+
+inline bool Environment::is_main_thread() const {
+  return worker_context_ == nullptr;
+}
+
+inline bool Environment::is_worker_thread() const {
+  return !is_main_thread();
+}
+
+inline size_t Environment::sub_worker_context_count() const {
+  return sub_worker_context_count_;
+};
+
 inline Environment* Environment::from_cares_timer_handle(uv_timer_t* handle) {
   return ContainerOf(&Environment::cares_timer_handle_, handle);
 }
@@ -368,6 +460,10 @@ inline ares_channel* Environment::cares_channel_ptr() {
 
 inline ares_task_list* Environment::cares_task_list() {
   return &cares_task_list_;
+}
+
+inline void Environment::set_using_cares() {
+  using_cares_ = true;
 }
 
 inline Environment::IsolateData* Environment::isolate_data() const {
@@ -464,6 +560,55 @@ inline void Environment::SetTemplateMethod(v8::Local<v8::FunctionTemplate> that,
   function->SetName(name_string);  // NODE_SET_METHOD() compatibility.
 }
 
+inline void Environment::AddSubWorkerContext(WorkerContext* context) {
+  sub_worker_context_count_++;
+  sub_worker_context_list_dirty_ = true;
+  sub_worker_contexts()->PushBack(context);
+}
+
+inline void Environment::RemoveSubWorkerContext(WorkerContext* context) {
+  sub_worker_context_count_--;
+  sub_worker_context_list_dirty_ = true;
+  sub_worker_contexts()->Remove(context);
+}
+
+inline Environment::WorkerContextList* Environment::sub_worker_contexts() {
+  return &sub_worker_contexts_;
+}
+
+inline uv_mutex_t* Environment::ApiMutex() {
+  return is_worker_thread() ? worker_context()->api_mutex() : nullptr;
+}
+
+inline bool Environment::CanCallIntoJs() const {
+  return is_main_thread() ||
+         (is_worker_thread() && worker_context()->JsExecutionAllowed());
+}
+
+inline void Environment::Exit(int exit_code) {
+  if (is_main_thread())
+    exit(exit_code);
+  else
+    worker_context()->Exit(exit_code);
+}
+
+inline void Environment::ProcessNotifications() {
+  if (is_worker_thread())
+    WorkerContext::WorkerNotificationCallback(worker_context());
+
+  process_owner_notifications:
+  sub_worker_context_list_dirty_ = false;
+  for (WorkerContext* context : *sub_worker_contexts()) {
+    WorkerContext::OwnerNotificationCallback(context);
+    // The loop needs to be restarted if the list changed while in-loop.
+    // The list will only change if a worker is being terminated abruptly,
+    // which is a rare occurrence, so restarting the loop should not be a
+    // problem performance-wise.
+    if (sub_worker_context_list_dirty_)
+      goto process_owner_notifications;
+  }
+}
+
 #define V(PropertyName, StringValue)                                          \
   inline                                                                      \
   v8::Local<v8::String> Environment::IsolateData::PropertyName() const {      \
@@ -480,6 +625,21 @@ inline void Environment::SetTemplateMethod(v8::Local<v8::FunctionTemplate> that,
   PER_ISOLATE_STRING_PROPERTIES(V)
 #undef V
 
+#define V(PropertyName, StringName)                                           \
+  inline                                                                      \
+  v8::Local<v8::Symbol> Environment::IsolateData::PropertyName() const {      \
+    return const_cast<IsolateData*>(this)->PropertyName ## _.Get(isolate());  \
+  }
+  PER_ISOLATE_SYMBOL_PROPERTIES(V)
+#undef V
+
+#define V(PropertyName, StringName)                                           \
+  inline v8::Local<v8::Symbol> Environment::PropertyName() const {            \
+    return isolate_data()->PropertyName();                                    \
+  }
+  PER_ISOLATE_SYMBOL_PROPERTIES(V)
+#undef V
+
 #define V(PropertyName, TypeName)                                             \
   inline v8::Local<TypeName> Environment::PropertyName() const {              \
     return StrongPersistentToLocal(PropertyName ## _);                        \
@@ -492,6 +652,7 @@ inline void Environment::SetTemplateMethod(v8::Local<v8::FunctionTemplate> that,
 
 #undef ENVIRONMENT_STRONG_PERSISTENT_PROPERTIES
 #undef PER_ISOLATE_STRING_PROPERTIES
+#undef PER_ISOLATE_SYMBOL_PROPERTIES
 
 }  // namespace node
 

--- a/src/env.h
+++ b/src/env.h
@@ -9,6 +9,8 @@
 #include "util.h"
 #include "uv.h"
 #include "v8.h"
+#include "worker.h"
+#include "async-wrap.h"
 
 #include <stdint.h>
 
@@ -85,6 +87,7 @@ namespace node {
   V(exit_code_string, "exitCode")                                             \
   V(exit_string, "exit")                                                      \
   V(expire_string, "expire")                                                  \
+  V(experimental_workers_string, "experimental_workers")                      \
   V(exponent_string, "exponent")                                              \
   V(exports_string, "exports")                                                \
   V(ext_key_usage_string, "ext_key_usage")                                    \
@@ -253,6 +256,27 @@ namespace node {
   V(udp_constructor_function, v8::Function)                                   \
   V(write_wrap_constructor_function, v8::Function)                            \
 
+#define PER_ISOLATE_SYMBOL_PROPERTIES(V)                                      \
+  V(worker_init_symbol, "worker_init")                                        \
+
+
+// All weak persistent handles that need to be walked upon Environment
+// destruction should have defined a class id. Finalizers are not called even
+// when a V8 isolate (and its heap) are destroyed so non-JS resources are
+// easily leaked. The clean-ups for these are defined in
+// persistent-handle-cleanup.cc.
+//
+// The cleanup for resources that are backing strong persistent handles is
+// ensured in some other way, e.g. RegisterHandleCleanup.
+enum ClassId : uint16_t {
+  CONTEXTIFY_SCRIPT = 0xA10C + 1,
+#define V(PROVIDER)                                                           \
+  PROVIDER_CLASS_ID_ ## PROVIDER =                                            \
+      AsyncWrap::PROVIDER_ ## PROVIDER + NODE_ASYNC_ID_OFFSET,
+  NODE_ASYNC_PROVIDER_TYPES(V)
+#undef V
+};
+
 class Environment;
 
 // TODO(bnoordhuis) Rename struct, the ares_ prefix implies it's part
@@ -265,6 +289,25 @@ struct ares_task_t {
 };
 
 RB_HEAD(ares_task_list, ares_task_t);
+
+typedef void (*HandleCleanupCb)(Environment* env,
+                                uv_handle_t* handle,
+                                void* arg);
+class HandleCleanup {
+ private:
+  friend class Environment;
+
+  HandleCleanup(uv_handle_t* handle, HandleCleanupCb cb, void* arg)
+      : handle_(handle),
+        cb_(cb),
+        arg_(arg) {
+  }
+
+  uv_handle_t* handle_;
+  HandleCleanupCb cb_;
+  void* arg_;
+  ListNode<HandleCleanup> handle_cleanup_queue_;
+};
 
 class Environment {
  public:
@@ -339,26 +382,6 @@ class Environment {
     DISALLOW_COPY_AND_ASSIGN(TickInfo);
   };
 
-  typedef void (*HandleCleanupCb)(Environment* env,
-                                  uv_handle_t* handle,
-                                  void* arg);
-
-  class HandleCleanup {
-   private:
-    friend class Environment;
-
-    HandleCleanup(uv_handle_t* handle, HandleCleanupCb cb, void* arg)
-        : handle_(handle),
-          cb_(cb),
-          arg_(arg) {
-    }
-
-    uv_handle_t* handle_;
-    HandleCleanupCb cb_;
-    void* arg_;
-    ListNode<HandleCleanup> handle_cleanup_queue_;
-  };
-
   static inline Environment* GetCurrent(v8::Isolate* isolate);
   static inline Environment* GetCurrent(v8::Local<v8::Context> context);
   static inline Environment* GetCurrent(
@@ -370,7 +393,8 @@ class Environment {
 
   // See CreateEnvironment() in src/node.cc.
   static inline Environment* New(v8::Local<v8::Context> context,
-                                 uv_loop_t* loop);
+                                 uv_loop_t* loop,
+                                 WorkerContext* worker_context = nullptr);
   inline void CleanupHandles();
   inline void Dispose();
 
@@ -393,10 +417,11 @@ class Environment {
   inline uv_check_t* idle_check_handle();
 
   // Register clean-up cb to be called on env->Dispose()
-  inline void RegisterHandleCleanup(uv_handle_t* handle,
-                                    HandleCleanupCb cb,
-                                    void *arg);
+  inline HandleCleanup* RegisterHandleCleanup(uv_handle_t* handle,
+                                              HandleCleanupCb cb,
+                                              void *arg);
   inline void FinishHandleCleanup(uv_handle_t* handle);
+  inline void DeregisterHandleCleanup(HandleCleanup* hc);
 
   inline AsyncHooks* async_hooks();
   inline DomainFlag* domain_flag();
@@ -408,6 +433,7 @@ class Environment {
   inline ares_channel cares_channel();
   inline ares_channel* cares_channel_ptr();
   inline ares_task_list* cares_task_list();
+  inline void set_using_cares();
 
   inline bool using_abort_on_uncaught_exc() const;
   inline void set_using_abort_on_uncaught_exc(bool value);
@@ -431,6 +457,19 @@ class Environment {
 
   inline char* http_parser_buffer() const;
   inline void set_http_parser_buffer(char* buffer);
+
+  inline WorkerContext* worker_context() const;
+  inline void set_worker_context(WorkerContext* context);
+
+  inline Environment* owner_env() const;
+  inline void set_owner_env(Environment* env);
+
+  inline size_t thread_id() const;
+
+  inline bool is_main_thread() const;
+  inline bool is_worker_thread() const;
+
+  inline size_t sub_worker_context_count() const;
 
   inline void ThrowError(const char* errmsg);
   inline void ThrowTypeError(const char* errmsg);
@@ -466,6 +505,18 @@ class Environment {
                                 const char* name,
                                 v8::FunctionCallback callback);
 
+  typedef
+  ListHead<WorkerContext,
+           &WorkerContext::subworker_list_member_> WorkerContextList;
+
+  inline uv_mutex_t* ApiMutex();
+  inline bool CanCallIntoJs() const;
+  inline void AddSubWorkerContext(WorkerContext* context);
+  inline void RemoveSubWorkerContext(WorkerContext* context);
+  inline WorkerContextList* sub_worker_contexts();
+  inline void Exit(int exit_code = 0);
+  inline void ProcessNotifications();
+  inline void TerminateSubWorkers();
 
   // Strings are shared across shared contexts. The getters simply proxy to
   // the per-isolate primitive.
@@ -478,6 +529,11 @@ class Environment {
   inline v8::Local<TypeName> PropertyName() const;                            \
   inline void set_ ## PropertyName(v8::Local<TypeName> value);
   ENVIRONMENT_STRONG_PERSISTENT_PROPERTIES(V)
+#undef V
+
+#define V(PropertyName, StringName)                                           \
+  inline v8::Local<v8::Symbol> PropertyName() const;
+  PER_ISOLATE_SYMBOL_PROPERTIES(V)
 #undef V
 
   inline debugger::Agent* debugger_agent() {
@@ -497,12 +553,16 @@ class Environment {
   static const int kIsolateSlot = NODE_ISOLATE_SLOT;
 
   class IsolateData;
-  inline Environment(v8::Local<v8::Context> context, uv_loop_t* loop);
+  inline Environment(v8::Local<v8::Context> context,
+                     uv_loop_t* loop,
+                     size_t thread_id);
   inline ~Environment();
   inline IsolateData* isolate_data() const;
 
   v8::Isolate* const isolate_;
   IsolateData* const isolate_data_;
+  WorkerContext* worker_context_ = nullptr;
+  Environment* owner_env_ = nullptr;
   uv_check_t immediate_check_handle_;
   uv_idle_t immediate_idle_handle_;
   uv_prepare_t idle_prepare_handle_;
@@ -519,13 +579,18 @@ class Environment {
   bool using_asyncwrap_;
   bool printed_error_;
   bool trace_sync_io_;
+  bool using_cares_ = false;
   debugger::Agent debugger_agent_;
 
   HandleWrapQueue handle_wrap_queue_;
   ReqWrapQueue req_wrap_queue_;
   ListHead<HandleCleanup,
            &HandleCleanup::handle_cleanup_queue_> handle_cleanup_queue_;
-  int handle_cleanup_waiting_;
+  WorkerContextList sub_worker_contexts_;
+  size_t sub_worker_context_count_ = 0;
+  size_t handle_cleanup_waiting_ = 0;
+  size_t const thread_id_;
+  bool sub_worker_context_list_dirty_ = false;
 
   uint32_t* heap_statistics_buffer_ = nullptr;
 
@@ -549,6 +614,11 @@ class Environment {
     PER_ISOLATE_STRING_PROPERTIES(V)
 #undef V
 
+#define V(PropertyName, StringName)                                           \
+    inline v8::Local<v8::Symbol> PropertyName() const;
+    PER_ISOLATE_SYMBOL_PROPERTIES(V)
+#undef V
+
    private:
     inline static IsolateData* Get(v8::Isolate* isolate);
     inline explicit IsolateData(v8::Isolate* isolate, uv_loop_t* loop);
@@ -560,6 +630,11 @@ class Environment {
 #define V(PropertyName, StringValue)                                          \
     v8::Eternal<v8::String> PropertyName ## _;
     PER_ISOLATE_STRING_PROPERTIES(V)
+#undef V
+
+#define V(PropertyName, StringName)                                          \
+    v8::Eternal<v8::Symbol> PropertyName ## _;
+    PER_ISOLATE_SYMBOL_PROPERTIES(V)
 #undef V
 
     unsigned int ref_count_;

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -36,6 +36,7 @@ class FSEventWrap: public HandleWrap {
   FSEventWrap(Environment* env, Local<Object> object);
   virtual ~FSEventWrap() override;
 
+  static void HandleWillForceClose(HandleWrap* wrap, uv_handle_t* handle);
   static void OnEvent(uv_fs_event_t* handle, const char* filename, int events,
     int status);
 
@@ -98,6 +99,8 @@ void FSEventWrap::Start(const FunctionCallbackInfo<Value>& args) {
 
   int err = uv_fs_event_init(wrap->env()->event_loop(), &wrap->handle_);
   if (err == 0) {
+    wrap->RegisterHandleCleanup(reinterpret_cast<uv_handle_t*>(&wrap->handle_),
+                                HandleWillForceClose);
     wrap->initialized_ = true;
 
     err = uv_fs_event_start(&wrap->handle_, OnEvent, *path, flags);
@@ -160,6 +163,11 @@ void FSEventWrap::OnEvent(uv_fs_event_t* handle, const char* filename,
   }
 
   wrap->MakeCallback(env->onchange_string(), ARRAY_SIZE(argv), argv);
+}
+
+
+void FSEventWrap::HandleWillForceClose(HandleWrap* wrap, uv_handle_t* handle) {
+  static_cast<FSEventWrap*>(wrap)->initialized_ = false;
 }
 
 

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -92,14 +92,63 @@ void HandleWrap::OnClose(uv_handle_t* handle) {
   Context::Scope context_scope(env->context());
   Local<Object> object = wrap->object();
 
-  if (wrap->flags_ & kCloseCallback) {
+  if (wrap->flags_ & kCloseCallback)
     wrap->MakeCallback(env->onclose_string(), 0, nullptr);
+
+  if (wrap->flags_ & kEnvironmentCleanup) {
+    CHECK_EQ(wrap->hc_, nullptr);
+    env->FinishHandleCleanup(handle);
+  } else if (wrap->hc_ != nullptr) {
+    // Prevent double clean ups.
+    env->DeregisterHandleCleanup(wrap->hc_);
+    wrap->hc_ = nullptr;
   }
 
-  object->SetAlignedPointerInInternalField(0, nullptr);
+  node::ClearWrap(object);
   wrap->persistent().Reset();
+  handle->data = nullptr;
   delete wrap;
 }
 
+
+void HandleWrap::HandleCleanupCallback(Environment* env,
+                                       uv_handle_t* handle,
+                                       void* arg) {
+  if (handle->data == nullptr)
+    return;
+
+  HandleWrap* wrap = static_cast<HandleWrap*>(handle->data);
+  // At this point Environment has freed the HandleCleanup* and this is the
+  // first opportunity to nullify it.
+  // TODO(petkaantonov) it would be more symmetric with DeregisterHandleCleanup
+  // if the HandleCleanup* was deleted in FinishHandleCleanup but it requires
+  // changing all other users of RegisterHandleCleanup
+  wrap->hc_ = nullptr;
+  if (handle != nullptr && !uv_is_closing(handle)) {
+    if (arg != nullptr) {
+      CallbackContainer* container = static_cast<CallbackContainer*>(arg);
+      container->cb_(wrap, handle);
+      delete container;
+    }
+    // Removes CloseCallback flag as well, EnvironmentCleanup means we are
+    // exiting.
+    wrap->flags_ = kEnvironmentCleanup;
+    uv_close(handle, OnClose);
+    wrap->handle__ = nullptr;
+  }
+}
+
+
+void HandleWrap::RegisterHandleCleanup(uv_handle_t* handle,
+                                       HandleWillForceCloseCb cb) {
+  CHECK_EQ(hc_, nullptr);
+
+  CallbackContainer* container =
+      cb == nullptr ? nullptr : new CallbackContainer(cb);
+
+  hc_ = env()->RegisterHandleCleanup(handle,
+                                     HandleCleanupCallback,
+                                     container);
+}
 
 }  // namespace node

--- a/src/node-contextify.h
+++ b/src/node-contextify.h
@@ -1,0 +1,42 @@
+#ifndef SRC_NODE_CONTEXTIFY_H_
+#define SRC_NODE_CONTEXTIFY_H_
+
+#include "base-object.h"
+#include "env.h"
+#include "v8.h"
+
+namespace node {
+
+class ContextifyScript : public BaseObject {
+  public:
+    ContextifyScript(Environment* env, v8::Local<v8::Object> object);
+    ~ContextifyScript() override;
+
+    void Dispose();
+    static void Init(Environment* env, v8::Local<v8::Object> target);
+    // args: code, [options]
+    static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
+    static bool InstanceOf(Environment* env, const v8::Local<v8::Value>& value);
+    // args: [options]
+    static void RunInThisContext(
+        const v8::FunctionCallbackInfo<v8::Value>& args);
+    // args: sandbox, [options]
+    static void RunInContext(const v8::FunctionCallbackInfo<v8::Value>& args);
+    static int64_t GetTimeoutArg(
+        const v8::FunctionCallbackInfo<v8::Value>& args, const int i);
+    static bool GetDisplayErrorsArg(
+        const v8::FunctionCallbackInfo<v8::Value>& args, const int i);
+    static v8::Local<v8::String> GetFilenameArg(
+        const v8::FunctionCallbackInfo<v8::Value>& args, const int i);
+    static bool EvalMachine(Environment* env,
+                            const int64_t timeout,
+                            const bool display_errors,
+                            const v8::FunctionCallbackInfo<v8::Value>& args,
+                            v8::TryCatch& try_catch);
+  private:
+    v8::Persistent<v8::UnboundScript> script_;
+};
+
+}  // namespace node
+
+#endif  // SRC_NODE_CONTEXTIFY_H_

--- a/src/node.cc
+++ b/src/node.cc
@@ -42,6 +42,7 @@
 #include "v8-debug.h"
 #include "v8-profiler.h"
 #include "zlib.h"
+#include "worker.h"
 
 #include <errno.h>
 #include <limits.h>  // PATH_MAX
@@ -142,14 +143,22 @@ static const char* icu_data_dir = nullptr;
 
 // used by C++ modules as well
 bool no_deprecation = false;
+bool experimental_workers = false;
+v8::Platform* default_platform = nullptr;
 
 // process-relative uptime base, initialized at start-up
 static double prog_start_time;
 static bool debugger_running;
+// Needed for potentially non-thread-safe process-globals
+static uv_mutex_t process_mutex;
+// Workers have read-only access to process-globals but cannot write them
+static uv_rwlock_t process_rwlock;
 static uv_async_t dispatch_debug_messages_async;
-
+static uv_thread_t process_main_thread;
 static Isolate* node_isolate = nullptr;
-static v8::Platform* default_platform;
+
+static size_t thread_id_counter = 1;
+static uv_mutex_t thread_id_counter_mutex;
 
 
 static void CheckImmediate(uv_check_t* handle) {
@@ -994,6 +1003,8 @@ Local<Value> MakeCallback(Environment* env,
                            const Local<Function> callback,
                            int argc,
                            Local<Value> argv[]) {
+  if (!env->CanCallIntoJs())
+    return Undefined(env->isolate());
   // If you hit this assertion, you forgot to enter the v8::Context first.
   CHECK_EQ(env->context(), env->isolate()->GetCurrentContext());
 
@@ -1019,7 +1030,7 @@ Local<Value> MakeCallback(Environment* env,
     }
   }
 
-  TryCatch try_catch;
+  TryCatch try_catch(env->isolate());
   try_catch.SetVerbose(true);
 
   if (has_domain) {
@@ -1034,6 +1045,8 @@ Local<Value> MakeCallback(Environment* env,
   if (has_async_queue) {
     try_catch.SetVerbose(false);
     env->async_hooks_pre_function()->Call(object, 0, nullptr);
+    if (try_catch.HasTerminated())
+      return Undefined(env->isolate());
     if (try_catch.HasCaught())
       FatalError("node::MakeCallback", "pre hook threw");
     try_catch.SetVerbose(true);
@@ -1041,9 +1054,16 @@ Local<Value> MakeCallback(Environment* env,
 
   Local<Value> ret = callback->Call(recv, argc, argv);
 
+  if (try_catch.HasTerminated()) {
+    CHECK(!env->CanCallIntoJs());
+    return Undefined(env->isolate());
+  }
+
   if (has_async_queue) {
     try_catch.SetVerbose(false);
     env->async_hooks_post_function()->Call(object, 0, nullptr);
+    if (try_catch.HasTerminated())
+      return Undefined(env->isolate());
     if (try_catch.HasCaught())
       FatalError("node::MakeCallback", "post hook threw");
     try_catch.SetVerbose(true);
@@ -1368,6 +1388,7 @@ void AppendExceptionLine(Environment* env,
   if (env->printed_error())
     return;
   env->set_printed_error(true);
+  ScopedLock::Mutex lock(&process_mutex);
   uv_tty_reset_mode();
   fprintf(stderr, "\n%s", arrow);
 }
@@ -1462,13 +1483,15 @@ static Local<Value> ExecuteString(Environment* env,
   Local<v8::Script> script = v8::Script::Compile(source, filename);
   if (script.IsEmpty()) {
     ReportException(env, try_catch);
-    exit(3);
+    env->Exit(3);
+    return Local<Value>();
   }
 
   Local<Value> result = script->Run();
   if (result.IsEmpty()) {
     ReportException(env, try_catch);
-    exit(4);
+    env->Exit(4);
+    return Local<Value>();
   }
 
   return scope.Escape(result);
@@ -1520,6 +1543,7 @@ static void Abort(const FunctionCallbackInfo<Value>& args) {
 
 static void Chdir(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  CHECK(env->is_main_thread());
 
   if (args.Length() != 1 || !args[0]->IsString()) {
     return env->ThrowTypeError("Bad argument.");
@@ -1563,6 +1587,8 @@ static void Umask(const FunctionCallbackInfo<Value>& args) {
   if (args.Length() < 1 || args[0]->IsUndefined()) {
     old = umask(0);
     umask(static_cast<mode_t>(old));
+  } else if (env->is_worker_thread()) {
+    return env->ThrowRangeError("cannot set umask from a worker");
   } else if (!args[0]->IsInt32() && !args[0]->IsString()) {
     return env->ThrowTypeError("argument must be an integer or octal string.");
   } else {
@@ -1720,6 +1746,7 @@ static void GetEGid(const FunctionCallbackInfo<Value>& args) {
 
 static void SetGid(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  CHECK(env->is_main_thread());
 
   if (!args[0]->IsUint32() && !args[0]->IsString()) {
     return env->ThrowTypeError("setgid argument must be a number or a string");
@@ -1739,6 +1766,7 @@ static void SetGid(const FunctionCallbackInfo<Value>& args) {
 
 static void SetEGid(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  CHECK(env->is_main_thread());
 
   if (!args[0]->IsUint32() && !args[0]->IsString()) {
     return env->ThrowTypeError("setegid argument must be a number or string");
@@ -1758,6 +1786,7 @@ static void SetEGid(const FunctionCallbackInfo<Value>& args) {
 
 static void SetUid(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  CHECK(env->is_main_thread());
 
   if (!args[0]->IsUint32() && !args[0]->IsString()) {
     return env->ThrowTypeError("setuid argument must be a number or a string");
@@ -1777,6 +1806,7 @@ static void SetUid(const FunctionCallbackInfo<Value>& args) {
 
 static void SetEUid(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  CHECK(env->is_main_thread());
 
   if (!args[0]->IsUint32() && !args[0]->IsString()) {
     return env->ThrowTypeError("seteuid argument must be a number or string");
@@ -1914,7 +1944,7 @@ static void InitGroups(const FunctionCallbackInfo<Value>& args) {
 
 
 void Exit(const FunctionCallbackInfo<Value>& args) {
-  exit(args[0]->Int32Value());
+  Environment::GetCurrent(args)->Exit(args[0]->Int32Value());
 }
 
 
@@ -1923,6 +1953,8 @@ static void Uptime(const FunctionCallbackInfo<Value>& args) {
   double uptime;
 
   uv_update_time(env->event_loop());
+  // TODO(petkaantonov) Will report the main instance's uptime even when
+  // called inside a worker instance
   uptime = uv_now(env->event_loop()) - prog_start_time;
 
   args.GetReturnValue().Set(Number::New(env->isolate(), uptime / 1000));
@@ -2157,7 +2189,7 @@ void FatalException(Isolate* isolate,
     // failed before the process._fatalException function was added!
     // this is probably pretty bad.  Nothing to do but report and exit.
     ReportException(env, error, message);
-    exit(6);
+    return env->Exit(6);
   }
 
   TryCatch fatal_try_catch;
@@ -2172,12 +2204,12 @@ void FatalException(Isolate* isolate,
   if (fatal_try_catch.HasCaught()) {
     // the fatal exception function threw, so we must exit
     ReportException(env, fatal_try_catch);
-    exit(7);
+    return env->Exit(7);
   }
 
   if (false == caught->BooleanValue()) {
     ReportException(env, error, message);
-    exit(1);
+    return env->Exit(1);
   }
 }
 
@@ -2199,6 +2231,9 @@ void OnMessage(Local<Message> message, Local<Value> error) {
 
 static void Binding(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  ScopedLock::Mutex lock(env->ApiMutex());
+  if (!env->CanCallIntoJs())
+    return;
 
   Local<String> module = args[0]->ToString(env->isolate());
   node::Utf8Value module_v(env->isolate(), module);
@@ -2294,7 +2329,12 @@ static void LinkedBinding(const FunctionCallbackInfo<Value>& args) {
 static void ProcessTitleGetter(Local<String> property,
                                const PropertyCallbackInfo<Value>& info) {
   char buffer[512];
-  uv_get_process_title(buffer, sizeof(buffer));
+  {
+    // FIXME(petkaantonov) remove this when
+    // https://github.com/libuv/libuv/issues/271 is resolved.
+    ScopedLock::Read lock(&process_rwlock);
+    uv_get_process_title(buffer, sizeof(buffer));
+  }
   info.GetReturnValue().Set(String::NewFromUtf8(info.GetIsolate(), buffer));
 }
 
@@ -2303,7 +2343,9 @@ static void ProcessTitleSetter(Local<String> property,
                                Local<Value> value,
                                const PropertyCallbackInfo<void>& info) {
   node::Utf8Value title(info.GetIsolate(), value);
-  // TODO(piscisaureus): protect with a lock
+  // FIXME(petkaantonov) remove this when
+  // https://github.com/libuv/libuv/issues/271 is resolved.
+  ScopedLock::Write lock(&process_rwlock);
   uv_set_process_title(*title);
 }
 
@@ -2311,6 +2353,7 @@ static void ProcessTitleSetter(Local<String> property,
 static void EnvGetter(Local<String> property,
                       const PropertyCallbackInfo<Value>& info) {
   Isolate* isolate = info.GetIsolate();
+  ScopedLock::Read lock(&process_rwlock);
 #ifdef __POSIX__
   node::Utf8Value key(isolate, property);
   const char* val = getenv(*key);
@@ -2339,6 +2382,7 @@ static void EnvGetter(Local<String> property,
 static void EnvSetter(Local<String> property,
                       Local<Value> value,
                       const PropertyCallbackInfo<Value>& info) {
+  ScopedLock::Write lock(&process_rwlock);
 #ifdef __POSIX__
   node::Utf8Value key(info.GetIsolate(), property);
   node::Utf8Value val(info.GetIsolate(), value);
@@ -2360,6 +2404,7 @@ static void EnvSetter(Local<String> property,
 static void EnvQuery(Local<String> property,
                      const PropertyCallbackInfo<Integer>& info) {
   int32_t rc = -1;  // Not found unless proven otherwise.
+  ScopedLock::Read lock(&process_rwlock);
 #ifdef __POSIX__
   node::Utf8Value key(info.GetIsolate(), property);
   if (getenv(*key))
@@ -2386,6 +2431,7 @@ static void EnvQuery(Local<String> property,
 static void EnvDeleter(Local<String> property,
                        const PropertyCallbackInfo<Boolean>& info) {
   bool rc = true;
+  ScopedLock::Write lock(&process_rwlock);
 #ifdef __POSIX__
   node::Utf8Value key(info.GetIsolate(), property);
   rc = getenv(*key) != nullptr;
@@ -2407,6 +2453,7 @@ static void EnvDeleter(Local<String> property,
 
 static void EnvEnumerator(const PropertyCallbackInfo<Array>& info) {
   Isolate* isolate = info.GetIsolate();
+  ScopedLock::Read lock(&process_rwlock);
 #ifdef __POSIX__
   int size = 0;
   while (environ[size])
@@ -2500,12 +2547,16 @@ static Local<Object> GetFeatures(Environment* env) {
            Boolean::New(env->isolate(),
                         get_builtin_module("crypto") != nullptr));
 
+  obj->Set(env->experimental_workers_string(),
+           Boolean::New(env->isolate(), experimental_workers));
+
   return scope.Escape(obj);
 }
 
 
 static void DebugPortGetter(Local<String> property,
                             const PropertyCallbackInfo<Value>& info) {
+  ScopedLock::Read lock(&process_rwlock);
   info.GetReturnValue().Set(debug_port);
 }
 
@@ -2513,6 +2564,7 @@ static void DebugPortGetter(Local<String> property,
 static void DebugPortSetter(Local<String> property,
                             Local<Value> value,
                             const PropertyCallbackInfo<void>& info) {
+  ScopedLock::Write lock(&process_rwlock);
   debug_port = value->Int32Value();
 }
 
@@ -2619,8 +2671,18 @@ void SetupProcessObject(Environment* env,
 
   process->SetAccessor(env->title_string(),
                        ProcessTitleGetter,
-                       ProcessTitleSetter,
+                       env->is_main_thread() ? ProcessTitleSetter : nullptr,
                        env->as_external());
+
+  // process.isMainThread
+  READONLY_PROPERTY(process,
+                    "isMainThread",
+                    Boolean::New(env->isolate(), env->is_main_thread()));
+
+  // process.isWorkerThread
+  READONLY_PROPERTY(process,
+                    "isWorkerThread",
+                    Boolean::New(env->isolate(), env->is_worker_thread()));
 
   // process.version
   READONLY_PROPERTY(process,
@@ -2763,15 +2825,18 @@ void SetupProcessObject(Environment* env,
   // create process.env
   Local<ObjectTemplate> process_env_template =
       ObjectTemplate::New(env->isolate());
-  process_env_template->SetNamedPropertyHandler(EnvGetter,
-                                                EnvSetter,
-                                                EnvQuery,
-                                                EnvDeleter,
-                                                EnvEnumerator,
-                                                env->as_external());
+  process_env_template->SetNamedPropertyHandler(
+    EnvGetter,
+    env->is_main_thread() ? EnvSetter : nullptr,
+    EnvQuery,
+    env->is_main_thread() ? EnvDeleter : nullptr,
+    EnvEnumerator,
+    env->as_external());
   Local<Object> process_env = process_env_template->NewInstance();
   process->Set(env->env_string(), process_env);
 
+  READONLY_PROPERTY(process, "tid", Number::New(env->isolate(),
+                                                env->thread_id()));
   READONLY_PROPERTY(process, "pid", Integer::New(env->isolate(), getpid()));
   READONLY_PROPERTY(process, "features", GetFeatures(env));
   process->SetAccessor(env->need_imm_cb_string(),
@@ -2779,53 +2844,54 @@ void SetupProcessObject(Environment* env,
                        NeedImmediateCallbackSetter,
                        env->as_external());
 
-  // -e, --eval
-  if (eval_string) {
-    READONLY_PROPERTY(process,
-                      "_eval",
-                      String::NewFromUtf8(env->isolate(), eval_string));
-  }
-
-  // -p, --print
-  if (print_eval) {
-    READONLY_PROPERTY(process, "_print_eval", True(env->isolate()));
-  }
-
-  // -i, --interactive
-  if (force_repl) {
-    READONLY_PROPERTY(process, "_forceRepl", True(env->isolate()));
-  }
-
-  if (preload_module_count) {
-    CHECK(preload_modules);
-    Local<Array> array = Array::New(env->isolate());
-    for (unsigned int i = 0; i < preload_module_count; ++i) {
-      Local<String> module = String::NewFromUtf8(env->isolate(),
-                                                 preload_modules[i]);
-      array->Set(i, module);
+  if (env->is_main_thread()) {
+    // -e, --eval
+    if (eval_string) {
+      READONLY_PROPERTY(process,
+                        "_eval",
+                        String::NewFromUtf8(env->isolate(), eval_string));
     }
-    READONLY_PROPERTY(process,
-                      "_preload_modules",
-                      array);
 
-    delete[] preload_modules;
-    preload_modules = nullptr;
-    preload_module_count = 0;
-  }
+    // -p, --print
+    if (print_eval) {
+      READONLY_PROPERTY(process, "_print_eval", True(env->isolate()));
+    }
 
-  // --no-deprecation
-  if (no_deprecation) {
-    READONLY_PROPERTY(process, "noDeprecation", True(env->isolate()));
-  }
+    // -i, --interactive
+    if (force_repl) {
+      READONLY_PROPERTY(process, "_forceRepl", True(env->isolate()));
+    }
 
-  // --throw-deprecation
-  if (throw_deprecation) {
-    READONLY_PROPERTY(process, "throwDeprecation", True(env->isolate()));
-  }
+    if (preload_module_count) {
+      CHECK(preload_modules);
+      Local<Array> array = Array::New(env->isolate());
+      for (unsigned int i = 0; i < preload_module_count; ++i) {
+        Local<String> module = String::NewFromUtf8(env->isolate(),
+                                                   preload_modules[i]);
+        array->Set(i, module);
+      }
+      READONLY_PROPERTY(process,
+                        "_preload_modules",
+                        array);
+      delete[] preload_modules;
+      preload_modules = nullptr;
+      preload_module_count = 0;
+    }
 
-  // --trace-deprecation
-  if (trace_deprecation) {
-    READONLY_PROPERTY(process, "traceDeprecation", True(env->isolate()));
+    // --no-deprecation
+    if (no_deprecation) {
+      READONLY_PROPERTY(process, "noDeprecation", True(env->isolate()));
+    }
+
+    // --throw-deprecation
+    if (throw_deprecation) {
+      READONLY_PROPERTY(process, "throwDeprecation", True(env->isolate()));
+    }
+
+    // --trace-deprecation
+    if (trace_deprecation) {
+      READONLY_PROPERTY(process, "traceDeprecation", True(env->isolate()));
+    }
   }
 
   size_t exec_path_len = 2 * PATH_MAX;
@@ -2844,50 +2910,56 @@ void SetupProcessObject(Environment* env,
 
   process->SetAccessor(env->debug_port_string(),
                        DebugPortGetter,
-                       DebugPortSetter,
+                       env->is_main_thread() ? DebugPortSetter : nullptr,
                        env->as_external());
 
   // define various internal methods
-  env->SetMethod(process,
-                 "_startProfilerIdleNotifier",
-                 StartProfilerIdleNotifier);
-  env->SetMethod(process,
-                 "_stopProfilerIdleNotifier",
-                 StopProfilerIdleNotifier);
   env->SetMethod(process, "_getActiveRequests", GetActiveRequests);
   env->SetMethod(process, "_getActiveHandles", GetActiveHandles);
   env->SetMethod(process, "reallyExit", Exit);
-  env->SetMethod(process, "abort", Abort);
-  env->SetMethod(process, "chdir", Chdir);
   env->SetMethod(process, "cwd", Cwd);
 
+  if (env->is_main_thread()) {
+    env->SetMethod(process, "abort", Abort);
+    env->SetMethod(process,
+                   "_startProfilerIdleNotifier",
+                   StartProfilerIdleNotifier);
+    env->SetMethod(process,
+                   "_stopProfilerIdleNotifier",
+                   StopProfilerIdleNotifier);
+    env->SetMethod(process, "chdir", Chdir);
+  }
   env->SetMethod(process, "umask", Umask);
 
 #if defined(__POSIX__) && !defined(__ANDROID__)
   env->SetMethod(process, "getuid", GetUid);
   env->SetMethod(process, "geteuid", GetEUid);
-  env->SetMethod(process, "setuid", SetUid);
-  env->SetMethod(process, "seteuid", SetEUid);
-
-  env->SetMethod(process, "setgid", SetGid);
-  env->SetMethod(process, "setegid", SetEGid);
   env->SetMethod(process, "getgid", GetGid);
   env->SetMethod(process, "getegid", GetEGid);
-
   env->SetMethod(process, "getgroups", GetGroups);
-  env->SetMethod(process, "setgroups", SetGroups);
-  env->SetMethod(process, "initgroups", InitGroups);
+
+  if (env->is_main_thread()) {
+    env->SetMethod(process, "setuid", SetUid);
+    env->SetMethod(process, "seteuid", SetEUid);
+    env->SetMethod(process, "setgid", SetGid);
+    env->SetMethod(process, "setegid", SetEGid);
+    env->SetMethod(process, "setgroups", SetGroups);
+    env->SetMethod(process, "initgroups", InitGroups);
+  }
 #endif  // __POSIX__ && !defined(__ANDROID__)
 
   env->SetMethod(process, "_kill", Kill);
 
-  env->SetMethod(process, "_debugProcess", DebugProcess);
-  env->SetMethod(process, "_debugPause", DebugPause);
-  env->SetMethod(process, "_debugEnd", DebugEnd);
+  if (env->is_main_thread()) {
+    env->SetMethod(process, "_debugProcess", DebugProcess);
+    env->SetMethod(process, "_debugPause", DebugPause);
+    env->SetMethod(process, "_debugEnd", DebugEnd);
+  }
 
   env->SetMethod(process, "hrtime", Hrtime);
 
-  env->SetMethod(process, "dlopen", DLOpen);
+  if (env->is_main_thread())
+    env->SetMethod(process, "dlopen", DLOpen);
 
   env->SetMethod(process, "uptime", Uptime);
   env->SetMethod(process, "memoryUsage", MemoryUsage);
@@ -2905,6 +2977,7 @@ void SetupProcessObject(Environment* env,
 
 
 #undef READONLY_PROPERTY
+#undef READONLY_DONT_ENUM_PROPERTY
 
 
 static void AtExit() {
@@ -2949,8 +3022,6 @@ void LoadEnvironment(Environment* env) {
   // source code.)
 
   // The node.js file returns a function 'f'
-  atexit(AtExit);
-
   TryCatch try_catch;
 
   // Disable verbose mode to stop FatalException() handler from trying
@@ -2962,7 +3033,7 @@ void LoadEnvironment(Environment* env) {
   Local<Value> f_value = ExecuteString(env, MainSource(env), script_name);
   if (try_catch.HasCaught())  {
     ReportException(env, try_catch);
-    exit(10);
+    return env->Exit(10);
   }
   CHECK(f_value->IsFunction());
   Local<Function> f = Local<Function>::Cast(f_value);
@@ -3205,6 +3276,9 @@ static void ParseArgs(int* argc,
     } else if (strcmp(arg, "--expose-internals") == 0 ||
                strcmp(arg, "--expose_internals") == 0) {
       // consumed in js
+    } else if (strcmp(arg, "--experimental-workers") == 0 ||
+               strcmp(arg, "--experimental_workers") == 0) {
+      experimental_workers = true;
     } else {
       // V8 option.  Pass through as-is.
       new_v8_argv[new_v8_argc] = arg;
@@ -3523,6 +3597,7 @@ static void DebugEnd(const FunctionCallbackInfo<Value>& args) {
 
 
 inline void PlatformInit() {
+process_main_thread = uv_thread_self();
 #ifdef __POSIX__
   sigset_t sigmask;
   sigemptyset(&sigmask);
@@ -3593,6 +3668,7 @@ void Init(int* argc,
           const char** argv,
           int* exec_argc,
           const char*** exec_argv) {
+  atexit(AtExit);
   // Initialize prog_start_time to get relative uptime.
   prog_start_time = static_cast<double>(uv_now(uv_default_loop()));
 
@@ -3684,6 +3760,9 @@ static AtExitCallback* at_exit_functions_;
 
 // TODO(bnoordhuis) Turn into per-context event.
 void RunAtExit(Environment* env) {
+  if (env->is_worker_thread())
+    return;
+
   AtExitCallback* p = at_exit_functions_;
   at_exit_functions_ = nullptr;
 
@@ -3763,18 +3842,6 @@ Environment* CreateEnvironment(Isolate* isolate,
   return env;
 }
 
-static Environment* CreateEnvironment(Isolate* isolate,
-                                      Local<Context> context,
-                                      NodeInstanceData* instance_data) {
-  return CreateEnvironment(isolate,
-                           instance_data->event_loop(),
-                           context,
-                           instance_data->argc(),
-                           instance_data->argv(),
-                           instance_data->exec_argc(),
-                           instance_data->exec_argv());
-}
-
 
 static void HandleCloseCb(uv_handle_t* handle) {
   Environment* env = reinterpret_cast<Environment*>(handle->data);
@@ -3782,11 +3849,32 @@ static void HandleCloseCb(uv_handle_t* handle) {
 }
 
 
-static void HandleCleanup(Environment* env,
+static void HandleCleanupCallback(Environment* env,
                           uv_handle_t* handle,
                           void* arg) {
   handle->data = env;
   uv_close(handle, HandleCloseCb);
+}
+
+
+Environment* CreateEnvironment(Isolate* isolate,
+                               Local<Context> context,
+                               WorkerContext* worker_context) {
+  CHECK_NE(worker_context, nullptr);
+  HandleScope handle_scope(isolate);
+  Context::Scope context_scope(context);
+  Environment* env = Environment::New(context,
+                                      worker_context->worker_event_loop(),
+                                      worker_context);
+  InitializeEnvironment(env,
+                        isolate,
+                        worker_context->worker_event_loop(),
+                        context,
+                        worker_context->argc(),
+                        worker_context->argv(),
+                        worker_context->exec_argc(),
+                        worker_context->exec_argv());
+  return env;
 }
 
 
@@ -3801,7 +3889,26 @@ Environment* CreateEnvironment(Isolate* isolate,
 
   Context::Scope context_scope(context);
   Environment* env = Environment::New(context, loop);
+  InitializeEnvironment(env,
+                        isolate,
+                        loop,
+                        context,
+                        argc,
+                        argv,
+                        exec_argc,
+                        exec_argv);
+  return env;
+}
 
+
+void InitializeEnvironment(Environment* env,
+                           Isolate* isolate,
+                           uv_loop_t* loop,
+                           Local<Context> context,
+                           int argc,
+                           const char* const* argv,
+                           int exec_argc,
+                           const char* const* exec_argv) {
   isolate->SetAutorunMicrotasks(false);
 
   uv_check_init(env->event_loop(), env->immediate_check_handle());
@@ -3827,24 +3934,23 @@ Environment* CreateEnvironment(Isolate* isolate,
   // Register handle cleanups
   env->RegisterHandleCleanup(
       reinterpret_cast<uv_handle_t*>(env->immediate_check_handle()),
-      HandleCleanup,
+      HandleCleanupCallback,
       nullptr);
   env->RegisterHandleCleanup(
       reinterpret_cast<uv_handle_t*>(env->immediate_idle_handle()),
-      HandleCleanup,
+      HandleCleanupCallback,
       nullptr);
   env->RegisterHandleCleanup(
       reinterpret_cast<uv_handle_t*>(env->idle_prepare_handle()),
-      HandleCleanup,
+      HandleCleanupCallback,
       nullptr);
   env->RegisterHandleCleanup(
       reinterpret_cast<uv_handle_t*>(env->idle_check_handle()),
-      HandleCleanup,
+      HandleCleanupCallback,
       nullptr);
 
-  if (v8_is_profiling) {
+  if (env->is_main_thread() && v8_is_profiling)
     StartProfilerIdleNotifier(env);
-  }
 
   Local<FunctionTemplate> process_template = FunctionTemplate::New(isolate);
   process_template->SetClassName(FIXED_ONE_BYTE_STRING(isolate, "process"));
@@ -3854,38 +3960,60 @@ Environment* CreateEnvironment(Isolate* isolate,
 
   SetupProcessObject(env, argc, argv, exec_argc, exec_argv);
   LoadAsyncWrapperInfo(env);
+}
 
-  return env;
+// MSVC work-around for intrusive lists.
+namespace workaround {
+static ListHead <WorkerContext,
+                 &WorkerContext::cleanup_queue_member_> cleanup_queue_;
+}
+static uv_mutex_t cleanup_queue_mutex_;
+// Deleting WorkerContexts in response to their notification signals
+// will cause use-after-free inside libuv. So the final `delete this`
+// call must be made somewhere else.
+static void CleanupWorkerContexts() {
+  ScopedLock::Mutex lock(&cleanup_queue_mutex_);
+  while (WorkerContext* context = workaround::cleanup_queue_.PopFront())
+    delete context;
 }
 
 
-// Entry point for new node instances, also called directly for the main
-// node instance.
-static void StartNodeInstance(void* arg) {
-  NodeInstanceData* instance_data = static_cast<NodeInstanceData*>(arg);
+void QueueWorkerContextCleanup(WorkerContext* context) {
+  ScopedLock::Mutex lock(&cleanup_queue_mutex_);
+  workaround::cleanup_queue_.PushBack(context);
+}
+
+
+static int RunMainThread(int argc,
+                         const char** argv,
+                         int exec_argc,
+                         const char** exec_argv) {
   Isolate::CreateParams params;
   ArrayBufferAllocator array_buffer_allocator;
   params.array_buffer_allocator = &array_buffer_allocator;
-  Isolate* isolate = Isolate::New(params);
-  if (track_heap_objects) {
-    isolate->GetHeapProfiler()->StartTrackingHeapObjects(true);
-  }
-
   // Fetch a reference to the main isolate, so we have a reference to it
   // even when we need it to access it from another (debugger) thread.
-  if (instance_data->is_main())
-    node_isolate = isolate;
+  node_isolate = Isolate::New(params);
+  if (track_heap_objects)
+    node_isolate->GetHeapProfiler()->StartTrackingHeapObjects(true);
+
+  int exit_code = 1;
   {
-    Locker locker(isolate);
-    Isolate::Scope isolate_scope(isolate);
-    HandleScope handle_scope(isolate);
-    Local<Context> context = Context::New(isolate);
-    Environment* env = CreateEnvironment(isolate, context, instance_data);
+    Locker locker(node_isolate);
+    Isolate::Scope isolate_scope(node_isolate);
+    HandleScope handle_scope(node_isolate);
+    Local<Context> context = Context::New(node_isolate);
+    Environment* env = CreateEnvironment(node_isolate,
+                                         uv_default_loop(),
+                                         context,
+                                         argc,
+                                         argv,
+                                         exec_argc,
+                                         exec_argv);
     Context::Scope context_scope(context);
-    if (instance_data->is_main())
-      env->set_using_abort_on_uncaught_exc(abort_on_uncaught_exception);
+    env->set_using_abort_on_uncaught_exc(abort_on_uncaught_exception);
     // Start debug agent when argv has --debug
-    if (instance_data->use_debug_agent())
+    if (use_debug_agent)
       StartDebug(env, debug_wait_connect);
 
     LoadEnvironment(env);
@@ -3893,18 +4021,19 @@ static void StartNodeInstance(void* arg) {
     env->set_trace_sync_io(trace_sync_io);
 
     // Enable debugger
-    if (instance_data->use_debug_agent())
+    if (use_debug_agent)
       EnableDebug(env);
 
     {
-      SealHandleScope seal(isolate);
+      SealHandleScope seal(node_isolate);
       bool more;
       do {
-        v8::platform::PumpMessageLoop(default_platform, isolate);
+        v8::platform::PumpMessageLoop(default_platform, node_isolate);
         more = uv_run(env->event_loop(), UV_RUN_ONCE);
+        CleanupWorkerContexts();
 
         if (more == false) {
-          v8::platform::PumpMessageLoop(default_platform, isolate);
+          v8::platform::PumpMessageLoop(default_platform, node_isolate);
           EmitBeforeExit(env);
 
           // Emit `beforeExit` if the loop became alive either after emitting
@@ -3917,10 +4046,9 @@ static void StartNodeInstance(void* arg) {
     }
 
     env->set_trace_sync_io(false);
+    env->TerminateSubWorkers();
 
-    int exit_code = EmitExit(env);
-    if (instance_data->is_main())
-      instance_data->set_exit_code(exit_code);
+    exit_code = EmitExit(env);
     RunAtExit(env);
 
 #if defined(LEAK_SANITIZER)
@@ -3931,14 +4059,31 @@ static void StartNodeInstance(void* arg) {
     env = nullptr;
   }
 
-  CHECK_NE(isolate, nullptr);
-  isolate->Dispose();
-  isolate = nullptr;
-  if (instance_data->is_main())
-    node_isolate = nullptr;
+  CHECK_NE(node_isolate, nullptr);
+  node_isolate->Dispose();
+  node_isolate = nullptr;
+  return exit_code;
 }
 
+
+uv_thread_t* main_thread() {
+  return &process_main_thread;
+}
+
+
+size_t GenerateThreadId() {
+  ScopedLock::Mutex lock(&thread_id_counter_mutex);
+  size_t ret = thread_id_counter;
+  thread_id_counter++;
+  return ret;
+}
+
+
 int Start(int argc, char** argv) {
+  CHECK_EQ(uv_mutex_init(&process_mutex), 0);
+  CHECK_EQ(uv_mutex_init(&thread_id_counter_mutex), 0);
+  CHECK_EQ(uv_mutex_init(&cleanup_queue_mutex_), 0);
+  CHECK_EQ(uv_rwlock_init(&process_rwlock), 0);
   PlatformInit();
 
   CHECK_GT(argc, 0);
@@ -3963,25 +4108,22 @@ int Start(int argc, char** argv) {
   V8::InitializePlatform(default_platform);
   V8::Initialize();
 
-  int exit_code = 1;
-  {
-    NodeInstanceData instance_data(NodeInstanceType::MAIN,
-                                   uv_default_loop(),
-                                   argc,
-                                   const_cast<const char**>(argv),
-                                   exec_argc,
-                                   exec_argv,
-                                   use_debug_agent);
-    StartNodeInstance(&instance_data);
-    exit_code = instance_data.exit_code();
-  }
+  int exit_code = RunMainThread(argc,
+                                  const_cast<const char**>(argv),
+                                  exec_argc,
+                                  exec_argv);
   V8::Dispose();
+  V8::ShutdownPlatform();
 
   delete default_platform;
   default_platform = nullptr;
 
   delete[] exec_argv;
   exec_argv = nullptr;
+  uv_mutex_destroy(&process_mutex);
+  uv_mutex_destroy(&thread_id_counter_mutex);
+  uv_mutex_destroy(&cleanup_queue_mutex_);
+  uv_rwlock_destroy(&process_rwlock);
 
   return exit_code;
 }

--- a/src/node.js
+++ b/src/node.js
@@ -38,7 +38,7 @@
 
     // Do not initialize channel in debugger agent, it deletes env variable
     // and the main thread won't see it.
-    if (process.argv[1] !== '--debug-agent')
+    if (process.argv[1] !== '--debug-agent' && process.isMainThread)
       startup.processChannel();
 
     startup.processRawDebug();
@@ -49,8 +49,25 @@
     // are running from a script and running the REPL - but there are a few
     // others like the debugger or running --eval arguments. Here we decide
     // which mode we run in.
+    if (process.isWorkerThread) {
+      // Sets up the Worker wrapper object
+      NativeModule.require('worker');
 
-    if (NativeModule.exists('_third_party_main')) {
+      if (!process._eval) {
+        var path = NativeModule.require('path');
+        process.argv[1] = path.resolve(process.argv[1]);
+        var Module = NativeModule.require('module');
+      }
+
+      process._runMain = function() {
+        delete process._runMain;
+        startup.preloadModules();
+        if (process._eval)
+          evalScript('[eval]');
+        else
+          Module.runMain();
+      };
+    } else if (NativeModule.exists('_third_party_main')) {
       // To allow people to extend Node in different ways, this hook allows
       // one to drop a file lib/_third_party_main.js into the build
       // directory which will be executed instead of Node's normal loading.
@@ -213,6 +230,10 @@
       // If someone handled it, then great.  otherwise, die in C++ land
       // since that means that we'll exit the process, emit the 'exit' event
       if (!caught) {
+        if (process.isWorkerThread) {
+          NativeModule.require('worker')._workerFatalError(er);
+          return true;
+        }
         try {
           if (!process._exiting) {
             process._exiting = true;
@@ -645,6 +666,7 @@
     });
 
     process.__defineGetter__('stdin', function() {
+      if (process.isWorkerThread) return null;
       if (stdin) return stdin;
 
       var tty_wrap = process.binding('tty_wrap');
@@ -720,10 +742,12 @@
       return stdin;
     });
 
-    process.openStdin = function() {
-      process.stdin.resume();
-      return process.stdin;
-    };
+    if (process.isMainThread) {
+      process.openStdin = function() {
+        process.stdin.resume();
+        return process.stdin;
+      };
+    }
   };
 
   startup.processKillAndExit = function() {
@@ -796,7 +820,6 @@
           var errnoException = NativeModule.require('util')._errnoException;
           throw errnoException(err, 'uv_signal_start');
         }
-
         signalWraps[type] = wrap;
       }
     });
@@ -808,7 +831,6 @@
       }
     });
   };
-
 
   startup.processChannel = function() {
     // If we were spawned with env NODE_CHANNEL_FD then load that up and

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1,3 +1,5 @@
+#include "node-contextify.h"
+
 #include "node.h"
 #include "node_internals.h"
 #include "node_watchdog.h"
@@ -468,268 +470,277 @@ class ContextifyContext {
   }
 };
 
-class ContextifyScript : public BaseObject {
- private:
-  Persistent<UnboundScript> script_;
 
- public:
-  static void Init(Environment* env, Local<Object> target) {
-    HandleScope scope(env->isolate());
-    Local<String> class_name =
-        FIXED_ONE_BYTE_STRING(env->isolate(), "ContextifyScript");
+void ContextifyScript::Init(Environment* env, Local<Object> target) {
+  HandleScope scope(env->isolate());
+  Local<String> class_name =
+      FIXED_ONE_BYTE_STRING(env->isolate(), "ContextifyScript");
 
-    Local<FunctionTemplate> script_tmpl = env->NewFunctionTemplate(New);
-    script_tmpl->InstanceTemplate()->SetInternalFieldCount(1);
-    script_tmpl->SetClassName(class_name);
-    env->SetProtoMethod(script_tmpl, "runInContext", RunInContext);
-    env->SetProtoMethod(script_tmpl, "runInThisContext", RunInThisContext);
+  Local<FunctionTemplate> script_tmpl = env->NewFunctionTemplate(New);
+  script_tmpl->InstanceTemplate()->SetInternalFieldCount(1);
+  script_tmpl->SetClassName(class_name);
+  env->SetProtoMethod(script_tmpl, "runInContext", RunInContext);
+  env->SetProtoMethod(script_tmpl, "runInThisContext", RunInThisContext);
 
-    target->Set(class_name, script_tmpl->GetFunction());
-    env->set_script_context_constructor_template(script_tmpl);
-  }
+  target->Set(class_name, script_tmpl->GetFunction());
+  env->set_script_context_constructor_template(script_tmpl);
+}
 
 
   // args: code, [options]
-  static void New(const FunctionCallbackInfo<Value>& args) {
-    Environment* env = Environment::GetCurrent(args);
+void ContextifyScript::New(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
 
-    if (!args.IsConstructCall()) {
-      return env->ThrowError("Must call vm.Script as a constructor.");
-    }
-
-    ContextifyScript* contextify_script =
-        new ContextifyScript(env, args.This());
-
-    TryCatch try_catch;
-    Local<String> code = args[0]->ToString(env->isolate());
-    Local<String> filename = GetFilenameArg(args, 1);
-    bool display_errors = GetDisplayErrorsArg(args, 1);
-    if (try_catch.HasCaught()) {
-      try_catch.ReThrow();
-      return;
-    }
-
-    ScriptOrigin origin(filename);
-    ScriptCompiler::Source source(code, origin);
-    Local<UnboundScript> v8_script =
-        ScriptCompiler::CompileUnbound(env->isolate(), &source);
-
-    if (v8_script.IsEmpty()) {
-      if (display_errors) {
-        AppendExceptionLine(env, try_catch.Exception(), try_catch.Message());
-      }
-      try_catch.ReThrow();
-      return;
-    }
-    contextify_script->script_.Reset(env->isolate(), v8_script);
+  if (!args.IsConstructCall()) {
+    return env->ThrowError("Must call vm.Script as a constructor.");
   }
 
+  ContextifyScript* contextify_script =
+      new ContextifyScript(env, args.This());
+  contextify_script->persistent().SetWrapperClassId(
+      ClassId::CONTEXTIFY_SCRIPT);
 
-  static bool InstanceOf(Environment* env, const Local<Value>& value) {
-    return !value.IsEmpty() &&
-           env->script_context_constructor_template()->HasInstance(value);
+  TryCatch try_catch;
+  Local<String> code = args[0]->ToString(env->isolate());
+  Local<String> filename = GetFilenameArg(args, 1);
+  bool display_errors = GetDisplayErrorsArg(args, 1);
+  if (try_catch.HasCaught()) {
+    try_catch.ReThrow();
+    return;
   }
+
+  ScriptOrigin origin(filename);
+  ScriptCompiler::Source source(code, origin);
+  Local<UnboundScript> v8_script =
+      ScriptCompiler::CompileUnbound(env->isolate(), &source);
+
+  if (v8_script.IsEmpty()) {
+    if (display_errors) {
+      AppendExceptionLine(env, try_catch.Exception(), try_catch.Message());
+    }
+    try_catch.ReThrow();
+    return;
+  }
+  contextify_script->script_.Reset(env->isolate(), v8_script);
+}
+
+
+bool ContextifyScript::InstanceOf(Environment* env, const Local<Value>& value) {
+  return !value.IsEmpty() &&
+         env->script_context_constructor_template()->HasInstance(value);
+}
 
 
   // args: [options]
-  static void RunInThisContext(const FunctionCallbackInfo<Value>& args) {
-    // Assemble arguments
+void
+ContextifyScript::RunInThisContext(const FunctionCallbackInfo<Value>& args) {
+  // Assemble arguments
+  TryCatch try_catch;
+  uint64_t timeout = GetTimeoutArg(args, 0);
+  bool display_errors = GetDisplayErrorsArg(args, 0);
+  if (try_catch.HasCaught()) {
+    try_catch.ReThrow();
+    return;
+  }
+
+  // Do the eval within this context
+  Environment* env = Environment::GetCurrent(args);
+  EvalMachine(env, timeout, display_errors, args, try_catch);
+}
+
+  // args: sandbox, [options]
+void ContextifyScript::RunInContext(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+
+  int64_t timeout;
+  bool display_errors;
+
+  // Assemble arguments
+  if (!args[0]->IsObject()) {
+    return env->ThrowTypeError(
+        "contextifiedSandbox argument must be an object.");
+  }
+
+  Local<Object> sandbox = args[0].As<Object>();
+  {
     TryCatch try_catch;
-    uint64_t timeout = GetTimeoutArg(args, 0);
-    bool display_errors = GetDisplayErrorsArg(args, 0);
+    timeout = GetTimeoutArg(args, 1);
+    display_errors = GetDisplayErrorsArg(args, 1);
     if (try_catch.HasCaught()) {
       try_catch.ReThrow();
       return;
     }
-
-    // Do the eval within this context
-    Environment* env = Environment::GetCurrent(args);
-    EvalMachine(env, timeout, display_errors, args, try_catch);
   }
 
-  // args: sandbox, [options]
-  static void RunInContext(const FunctionCallbackInfo<Value>& args) {
-    Environment* env = Environment::GetCurrent(args);
+  // Get the context from the sandbox
+  ContextifyContext* contextify_context =
+      ContextifyContext::ContextFromContextifiedSandbox(env->isolate(),
+                                                        sandbox);
+  if (contextify_context == nullptr) {
+    return env->ThrowTypeError(
+        "sandbox argument must have been converted to a context.");
+  }
 
-    int64_t timeout;
-    bool display_errors;
+  if (contextify_context->context().IsEmpty())
+    return;
 
-    // Assemble arguments
-    if (!args[0]->IsObject()) {
-      return env->ThrowTypeError(
-          "contextifiedSandbox argument must be an object.");
+  {
+    TryCatch try_catch;
+    // Do the eval within the context
+    Context::Scope context_scope(contextify_context->context());
+    if (EvalMachine(contextify_context->env(),
+                    timeout,
+                    display_errors,
+                    args,
+                    try_catch)) {
+      contextify_context->CopyProperties();
     }
 
-    Local<Object> sandbox = args[0].As<Object>();
-    {
-      TryCatch try_catch;
-      timeout = GetTimeoutArg(args, 1);
-      display_errors = GetDisplayErrorsArg(args, 1);
-      if (try_catch.HasCaught()) {
-        try_catch.ReThrow();
-        return;
-      }
-    }
-
-    // Get the context from the sandbox
-    ContextifyContext* contextify_context =
-        ContextifyContext::ContextFromContextifiedSandbox(env->isolate(),
-                                                          sandbox);
-    if (contextify_context == nullptr) {
-      return env->ThrowTypeError(
-          "sandbox argument must have been converted to a context.");
-    }
-
-    if (contextify_context->context().IsEmpty())
+    if (try_catch.HasCaught()) {
+      try_catch.ReThrow();
       return;
-
-    {
-      TryCatch try_catch;
-      // Do the eval within the context
-      Context::Scope context_scope(contextify_context->context());
-      if (EvalMachine(contextify_context->env(),
-                      timeout,
-                      display_errors,
-                      args,
-                      try_catch)) {
-        contextify_context->CopyProperties();
-      }
-
-      if (try_catch.HasCaught()) {
-        try_catch.ReThrow();
-        return;
-      }
     }
   }
+}
 
-  static int64_t GetTimeoutArg(const FunctionCallbackInfo<Value>& args,
-                               const int i) {
-    if (args[i]->IsUndefined() || args[i]->IsString()) {
-      return -1;
-    }
-    if (!args[i]->IsObject()) {
-      Environment::ThrowTypeError(args.GetIsolate(),
-                                  "options must be an object");
-      return -1;
-    }
-
-    Local<String> key = FIXED_ONE_BYTE_STRING(args.GetIsolate(), "timeout");
-    Local<Value> value = args[i].As<Object>()->Get(key);
-    if (value->IsUndefined()) {
-      return -1;
-    }
-    int64_t timeout = value->IntegerValue();
-
-    if (timeout <= 0) {
-      Environment::ThrowRangeError(args.GetIsolate(),
-                                   "timeout must be a positive number");
-      return -1;
-    }
-    return timeout;
+int64_t ContextifyScript::GetTimeoutArg(const FunctionCallbackInfo<Value>& args,
+                                        const int i) {
+  if (args[i]->IsUndefined() || args[i]->IsString()) {
+    return -1;
+  }
+  if (!args[i]->IsObject()) {
+    Environment::ThrowTypeError(args.GetIsolate(),
+                                "options must be an object");
+    return -1;
   }
 
-
-  static bool GetDisplayErrorsArg(const FunctionCallbackInfo<Value>& args,
-                                  const int i) {
-    if (args[i]->IsUndefined() || args[i]->IsString()) {
-      return true;
-    }
-    if (!args[i]->IsObject()) {
-      Environment::ThrowTypeError(args.GetIsolate(),
-                                  "options must be an object");
-      return false;
-    }
-
-    Local<String> key = FIXED_ONE_BYTE_STRING(args.GetIsolate(),
-                                              "displayErrors");
-    Local<Value> value = args[i].As<Object>()->Get(key);
-
-    return value->IsUndefined() ? true : value->BooleanValue();
+  Local<String> key = FIXED_ONE_BYTE_STRING(args.GetIsolate(), "timeout");
+  Local<Value> value = args[i].As<Object>()->Get(key);
+  if (value->IsUndefined()) {
+    return -1;
   }
+  int64_t timeout = value->IntegerValue();
 
-
-  static Local<String> GetFilenameArg(const FunctionCallbackInfo<Value>& args,
-                                      const int i) {
-    Local<String> defaultFilename =
-        FIXED_ONE_BYTE_STRING(args.GetIsolate(), "evalmachine.<anonymous>");
-
-    if (args[i]->IsUndefined()) {
-      return defaultFilename;
-    }
-    if (args[i]->IsString()) {
-      return args[i].As<String>();
-    }
-    if (!args[i]->IsObject()) {
-      Environment::ThrowTypeError(args.GetIsolate(),
-                                  "options must be an object");
-      return Local<String>();
-    }
-
-    Local<String> key = FIXED_ONE_BYTE_STRING(args.GetIsolate(), "filename");
-    Local<Value> value = args[i].As<Object>()->Get(key);
-
-    if (value->IsUndefined())
-      return defaultFilename;
-    return value->ToString(args.GetIsolate());
+  if (timeout <= 0) {
+    Environment::ThrowRangeError(args.GetIsolate(),
+                                 "timeout must be a positive number");
+    return -1;
   }
+  return timeout;
+}
 
 
-  static bool EvalMachine(Environment* env,
-                          const int64_t timeout,
-                          const bool display_errors,
-                          const FunctionCallbackInfo<Value>& args,
-                          TryCatch& try_catch) {
-    if (!ContextifyScript::InstanceOf(env, args.Holder())) {
-      env->ThrowTypeError(
-          "Script methods can only be called on script instances.");
-      return false;
-    }
-
-    ContextifyScript* wrapped_script = Unwrap<ContextifyScript>(args.Holder());
-    Local<UnboundScript> unbound_script =
-        PersistentToLocal(env->isolate(), wrapped_script->script_);
-    Local<Script> script = unbound_script->BindToCurrentContext();
-
-    Local<Value> result;
-    if (timeout != -1) {
-      Watchdog wd(env, timeout);
-      result = script->Run();
-    } else {
-      result = script->Run();
-    }
-
-    if (try_catch.HasCaught() && try_catch.HasTerminated()) {
-      V8::CancelTerminateExecution(env->isolate());
-      env->ThrowError("Script execution timed out.");
-      try_catch.ReThrow();
-      return false;
-    }
-
-    if (result.IsEmpty()) {
-      // Error occurred during execution of the script.
-      if (display_errors) {
-        AppendExceptionLine(env, try_catch.Exception(), try_catch.Message());
-      }
-      try_catch.ReThrow();
-      return false;
-    }
-
-    args.GetReturnValue().Set(result);
+bool ContextifyScript::GetDisplayErrorsArg(
+    const FunctionCallbackInfo<Value>& args, const int i) {
+  if (args[i]->IsUndefined() || args[i]->IsString()) {
     return true;
   }
-
-
-  ContextifyScript(Environment* env, Local<Object> object)
-      : BaseObject(env, object) {
-    MakeWeak<ContextifyScript>(this);
+  if (!args[i]->IsObject()) {
+    Environment::ThrowTypeError(args.GetIsolate(),
+                                "options must be an object");
+    return false;
   }
 
+  Local<String> key = FIXED_ONE_BYTE_STRING(args.GetIsolate(),
+                                            "displayErrors");
+  Local<Value> value = args[i].As<Object>()->Get(key);
 
-  ~ContextifyScript() override {
-    script_.Reset();
+  return value->IsUndefined() ? true : value->BooleanValue();
+}
+
+
+Local<String> ContextifyScript::GetFilenameArg(
+    const FunctionCallbackInfo<Value>& args, const int i) {
+  Local<String> defaultFilename =
+      FIXED_ONE_BYTE_STRING(args.GetIsolate(), "evalmachine.<anonymous>");
+
+  if (args[i]->IsUndefined()) {
+    return defaultFilename;
   }
-};
+  if (args[i]->IsString()) {
+    return args[i].As<String>();
+  }
+  if (!args[i]->IsObject()) {
+    Environment::ThrowTypeError(args.GetIsolate(),
+                                "options must be an object");
+    return Local<String>();
+  }
 
+  Local<String> key = FIXED_ONE_BYTE_STRING(args.GetIsolate(), "filename");
+  Local<Value> value = args[i].As<Object>()->Get(key);
+
+  if (value->IsUndefined())
+    return defaultFilename;
+  return value->ToString(args.GetIsolate());
+}
+
+
+bool ContextifyScript::EvalMachine(Environment* env,
+                                   const int64_t timeout,
+                                   const bool display_errors,
+                                   const FunctionCallbackInfo<Value>& args,
+                                   TryCatch& try_catch) {
+  if (!env->CanCallIntoJs())
+    return false;
+  if (!ContextifyScript::InstanceOf(env, args.Holder())) {
+    env->ThrowTypeError(
+        "Script methods can only be called on script instances.");
+    return false;
+  }
+
+  ContextifyScript* wrapped_script = Unwrap<ContextifyScript>(args.Holder());
+  Local<UnboundScript> unbound_script =
+      PersistentToLocal(env->isolate(), wrapped_script->script_);
+  Local<Script> script = unbound_script->BindToCurrentContext();
+
+  Local<Value> result;
+  if (timeout != -1) {
+    Watchdog wd(env, timeout);
+    result = script->Run();
+  } else {
+    result = script->Run();
+  }
+
+  if (try_catch.HasCaught() && try_catch.HasTerminated()) {
+    // Check if terminated because the containing worker thread is terminated,
+    // not because of the watchdog.
+    if (!env->CanCallIntoJs()) {
+      try_catch.Reset();
+      return false;
+    }
+    V8::CancelTerminateExecution(env->isolate());
+    env->ThrowError("Script execution timed out.");
+    try_catch.ReThrow();
+    return false;
+  }
+
+  if (result.IsEmpty()) {
+    // Error occurred during execution of the script.
+    if (display_errors) {
+      AppendExceptionLine(env, try_catch.Exception(), try_catch.Message());
+    }
+    try_catch.ReThrow();
+    return false;
+  }
+
+  args.GetReturnValue().Set(result);
+  return true;
+}
+
+
+void ContextifyScript::Dispose() {
+  persistent().Reset();
+  delete this;
+}
+
+ContextifyScript::ContextifyScript(Environment* env, Local<Object> object)
+    : BaseObject(env, object) {
+  MakeWeak<ContextifyScript>(this);
+}
+
+ContextifyScript::~ContextifyScript() {
+  script_.Reset();
+}
 
 void InitContextify(Local<Object> target,
                     Local<Value> unused,

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4413,6 +4413,9 @@ void ECDH::Initialize(Environment* env, Local<Object> target) {
 void ECDH::New(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
+  ClearErrorOnReturn clear_error_on_return;
+  (void) &clear_error_on_return;  // Silence compiler warning.
+
   // TODO(indutny): Support raw curves?
   CHECK(args[0]->IsString());
   node::Utf8Value curve(env->isolate(), args[0]);
@@ -4432,6 +4435,9 @@ void ECDH::New(const FunctionCallbackInfo<Value>& args) {
 void ECDH::GenerateKeys(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
+  ClearErrorOnReturn clear_error_on_return;
+  (void) &clear_error_on_return;  // Silence compiler warning.
+
   ECDH* ecdh = Unwrap<ECDH>(args.Holder());
 
   if (!EC_KEY_generate_key(ecdh->key_))
@@ -4444,6 +4450,9 @@ void ECDH::GenerateKeys(const FunctionCallbackInfo<Value>& args) {
 EC_POINT* ECDH::BufferToPoint(char* data, size_t len) {
   EC_POINT* pub;
   int r;
+
+  ClearErrorOnReturn clear_error_on_return;
+  (void) &clear_error_on_return;  // Silence compiler warning.
 
   pub = EC_POINT_new(group_);
   if (pub == nullptr) {
@@ -4472,6 +4481,9 @@ EC_POINT* ECDH::BufferToPoint(char* data, size_t len) {
 
 void ECDH::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+
+  ClearErrorOnReturn clear_error_on_return;
+  (void) &clear_error_on_return;  // Silence compiler warning.
 
   THROW_AND_RETURN_IF_NOT_BUFFER(args[0]);
 
@@ -4502,6 +4514,9 @@ void ECDH::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
 
 void ECDH::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+
+  ClearErrorOnReturn clear_error_on_return;
+  (void) &clear_error_on_return;  // Silence compiler warning.
 
   // Conversion form
   CHECK_EQ(args.Length(), 1);
@@ -4541,6 +4556,9 @@ void ECDH::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
 void ECDH::GetPrivateKey(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
+  ClearErrorOnReturn clear_error_on_return;
+  (void) &clear_error_on_return;  // Silence compiler warning.
+
   ECDH* ecdh = Unwrap<ECDH>(args.Holder());
 
   if (!ecdh->generated_)
@@ -4568,6 +4586,9 @@ void ECDH::GetPrivateKey(const FunctionCallbackInfo<Value>& args) {
 void ECDH::SetPrivateKey(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
+  ClearErrorOnReturn clear_error_on_return;
+  (void) &clear_error_on_return;  // Silence compiler warning.
+
   ECDH* ecdh = Unwrap<ECDH>(args.Holder());
 
   THROW_AND_RETURN_IF_NOT_BUFFER(args[0]);
@@ -4590,6 +4611,9 @@ void ECDH::SetPrivateKey(const FunctionCallbackInfo<Value>& args) {
 
 void ECDH::SetPublicKey(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+
+  ClearErrorOnReturn clear_error_on_return;
+  (void) &clear_error_on_return;  // Silence compiler warning.
 
   ECDH* ecdh = Unwrap<ECDH>(args.Holder());
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -32,6 +32,7 @@ namespace node {
 
 // Forward declaration
 class Environment;
+class WorkerContext;
 
 // If persistent.IsWeak() == false, then do not call persistent.Reset()
 // while the returned Local<T> is still in scope, it will destroy the
@@ -136,7 +137,6 @@ void AppendExceptionLine(Environment* env,
                          v8::Local<v8::Message> message);
 
 NO_RETURN void FatalError(const char* location, const char* message);
-
 v8::Local<v8::Value> BuildStatsObject(Environment* env, const uv_stat_t* s);
 
 enum Endianness {
@@ -180,6 +180,23 @@ inline MUST_USE_RESULT bool ParseArrayIndex(v8::Local<v8::Value> arg,
   *ret = static_cast<size_t>(tmp_i);
   return true;
 }
+
+extern bool experimental_workers;
+extern v8::Platform* default_platform;
+uv_thread_t* main_thread();
+size_t GenerateThreadId();
+void QueueWorkerContextCleanup(WorkerContext* context);
+void InitializeEnvironment(Environment* env,
+                           v8::Isolate* isolate,
+                           uv_loop_t* loop,
+                           v8::Handle<v8::Context> context,
+                           int argc,
+                           const char* const* argv,
+                           int exec_argc,
+                           const char* const* exec_argv);
+Environment* CreateEnvironment(v8::Isolate* isolate,
+                               v8::Handle<v8::Context> context,
+                               WorkerContext* worker_context);
 
 void ThrowError(v8::Isolate* isolate, const char* errmsg);
 void ThrowTypeError(v8::Isolate* isolate, const char* errmsg);
@@ -240,83 +257,6 @@ struct ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
   virtual void Free(void* data, size_t) {
     free(data);
   }
-};
-
-enum NodeInstanceType { MAIN, WORKER };
-
-class NodeInstanceData {
-  public:
-    NodeInstanceData(NodeInstanceType node_instance_type,
-                     uv_loop_t* event_loop,
-                     int argc,
-                     const char** argv,
-                     int exec_argc,
-                     const char** exec_argv,
-                     bool use_debug_agent_flag)
-        : node_instance_type_(node_instance_type),
-          exit_code_(1),
-          event_loop_(event_loop),
-          argc_(argc),
-          argv_(argv),
-          exec_argc_(exec_argc),
-          exec_argv_(exec_argv),
-          use_debug_agent_flag_(use_debug_agent_flag) {
-      CHECK_NE(event_loop_, nullptr);
-    }
-
-    uv_loop_t* event_loop() const {
-      return event_loop_;
-    }
-
-    int exit_code() {
-      CHECK(is_main());
-      return exit_code_;
-    }
-
-    void set_exit_code(int exit_code) {
-      CHECK(is_main());
-      exit_code_ = exit_code;
-    }
-
-    bool is_main() {
-      return node_instance_type_ == MAIN;
-    }
-
-    bool is_worker() {
-      return node_instance_type_ == WORKER;
-    }
-
-    int argc() {
-      return argc_;
-    }
-
-    const char** argv() {
-      return argv_;
-    }
-
-    int exec_argc() {
-      return exec_argc_;
-    }
-
-    const char** exec_argv() {
-      return exec_argv_;
-    }
-
-    bool use_debug_agent() {
-      return is_main() && use_debug_agent_flag_;
-    }
-
-  private:
-    const NodeInstanceType node_instance_type_;
-    int exit_code_;
-    uv_loop_t* const event_loop_;
-    const int argc_;
-    const char** argv_;
-    const int exec_argc_;
-    const char** exec_argv_;
-    const bool use_debug_agent_flag_;
-
-    DISALLOW_COPY_AND_ASSIGN(NodeInstanceData);
 };
 
 namespace Buffer {

--- a/src/notification-channel.cc
+++ b/src/notification-channel.cc
@@ -1,0 +1,62 @@
+#include "notification-channel.h"
+
+#include "util.h"
+#include "util-inl.h"
+
+namespace node {
+
+NotificationChannel::NotificationChannel(uv_loop_t* loop,
+                                         NotificationCallback callback,
+                                         void* data)
+    : event_loop_(loop),
+      callback_(callback),
+      data_(data) {
+  CHECK_EQ(0, uv_async_init(event_loop(),
+                            notification_signal_async(),
+                            AsyncCallback));
+  Ref();
+  notification_signal_async()->data = this;
+}
+
+void NotificationChannel::Dispose() {
+  CHECK(!uv_is_closing(reinterpret_cast<uv_handle_t*>(
+      notification_signal_async())));
+  uv_close(reinterpret_cast<uv_handle_t*>(notification_signal_async()),
+           CloseCallback);
+
+  while (!close_callback_called_)
+    uv_run(event_loop(), UV_RUN_ONCE);
+
+  notification_signal_async()->data = nullptr;
+}
+
+void NotificationChannel::Ref() {
+  uv_ref(reinterpret_cast<uv_handle_t*>(notification_signal_async()));
+}
+
+void NotificationChannel::Unref() {
+  uv_unref(reinterpret_cast<uv_handle_t*>(notification_signal_async()));
+}
+
+void NotificationChannel::Notify() {
+  uv_async_send(notification_signal_async());
+}
+
+void NotificationChannel::AsyncCallback(uv_async_t* handle) {
+  NotificationChannel* channel =
+      static_cast<NotificationChannel*>(handle->data);
+  if (channel == nullptr ||
+      uv_is_closing(reinterpret_cast<uv_handle_t*>(
+          channel->notification_signal_async())))
+    return;
+
+  channel->callback_(channel->data_);
+}
+
+void NotificationChannel::CloseCallback(uv_handle_t* handle) {
+  NotificationChannel* channel =
+      static_cast<NotificationChannel*>(handle->data);
+  channel->close_callback_called_ = true;
+}
+
+}  // namespace node

--- a/src/notification-channel.h
+++ b/src/notification-channel.h
@@ -1,0 +1,46 @@
+#ifndef SRC_NOTIFICATION_CHANNEL_H_
+#define SRC_NOTIFICATION_CHANNEL_H_
+
+#include "uv.h"
+
+namespace node {
+
+typedef void (*NotificationCallback)(void* data);
+
+class NotificationChannel {
+  public:
+    NotificationChannel(uv_loop_t* event_loop,
+                        NotificationCallback callback,
+                        void* data);
+    void Dispose();
+    void Ref();
+    void Unref();
+    void Notify();
+
+  private:
+    uv_loop_t* event_loop() const {
+      return event_loop_;
+    }
+
+    uv_async_t* notification_signal_async()  {
+      return &notification_signal_async_;
+    }
+
+    uv_mutex_t* access_mutex() {
+      return &access_mutex_;
+    }
+
+    static void AsyncCallback(uv_async_t* handle);
+    static void CloseCallback(uv_handle_t* handle);
+
+    uv_loop_t* const event_loop_;
+    uv_async_t notification_signal_async_;
+    uv_mutex_t access_mutex_;
+    NotificationCallback const callback_;
+    bool close_callback_called_ = false;
+    void* data_;
+};
+
+}  // namespace node
+
+#endif  // SRC_NOTIFICATION_CHANNEL_H_

--- a/src/persistent-handle-cleanup.cc
+++ b/src/persistent-handle-cleanup.cc
@@ -1,0 +1,78 @@
+#include "persistent-handle-cleanup.h"
+
+#include "v8.h"
+
+#include "env.h"
+#include "env-inl.h"
+#include "node-contextify.h"
+#include "async-wrap.h"
+
+namespace node {
+
+using v8::Persistent;
+using v8::Value;
+using v8::Isolate;
+
+void PersistentHandleCleanup::VisitPersistentHandle(
+    Persistent<Value>* value, uint16_t class_id) {
+  Isolate::DisallowJavascriptExecutionScope scope(env()->isolate(),
+      Isolate::DisallowJavascriptExecutionScope::CRASH_ON_FAILURE);
+
+  if (value->IsWeak()) {
+    switch (static_cast<ClassId>(class_id)) {
+      case CONTEXTIFY_SCRIPT:
+        value->ClearWeak<ContextifyScript>()->Dispose();
+        break;
+      case PROVIDER_CLASS_ID_NONE:
+        break;
+      case PROVIDER_CLASS_ID_CARES:
+        break;
+      case PROVIDER_CLASS_ID_CONNECTWRAP:
+        break;
+      case PROVIDER_CLASS_ID_CRYPTO:
+        break;
+      case PROVIDER_CLASS_ID_FSEVENTWRAP:
+        break;
+      case PROVIDER_CLASS_ID_FSREQWRAP:
+        break;
+      case PROVIDER_CLASS_ID_GETADDRINFOREQWRAP:
+        break;
+      case PROVIDER_CLASS_ID_GETNAMEINFOREQWRAP:
+        break;
+      case PROVIDER_CLASS_ID_JSSTREAM:
+        break;
+      case PROVIDER_CLASS_ID_PIPEWRAP:
+        break;
+      case PROVIDER_CLASS_ID_PROCESSWRAP:
+        break;
+      case PROVIDER_CLASS_ID_QUERYWRAP:
+        break;
+      case PROVIDER_CLASS_ID_REQWRAP:
+        break;
+      case PROVIDER_CLASS_ID_SHUTDOWNWRAP:
+        break;
+      case PROVIDER_CLASS_ID_SIGNALWRAP:
+        break;
+      case PROVIDER_CLASS_ID_STATWATCHER:
+        break;
+      case PROVIDER_CLASS_ID_TCPWRAP:
+        break;
+      case PROVIDER_CLASS_ID_TIMERWRAP:
+        break;
+      case PROVIDER_CLASS_ID_TLSWRAP:
+        break;
+      case PROVIDER_CLASS_ID_TTYWRAP:
+        break;
+      case PROVIDER_CLASS_ID_UDPWRAP:
+        break;
+      case PROVIDER_CLASS_ID_WRITEWRAP:
+        break;
+      case PROVIDER_CLASS_ID_ZLIB:
+        break;
+      default: {}
+        // Addon class id
+    }
+  }
+};
+
+}  // namespace node

--- a/src/persistent-handle-cleanup.h
+++ b/src/persistent-handle-cleanup.h
@@ -1,0 +1,26 @@
+#ifndef SRC_PERSISTENT_HANDLE_CLEANUP_H_
+#define SRC_PERSISTENT_HANDLE_CLEANUP_H_
+
+#include "v8.h"
+#include "env.h"
+
+namespace node {
+
+class PersistentHandleCleanup : public v8::PersistentHandleVisitor {
+  public:
+    void VisitPersistentHandle(v8::Persistent<v8::Value>* value,
+                               uint16_t class_id) override;
+  private:
+    explicit PersistentHandleCleanup(Environment* env) : env_(env) {}
+
+    Environment* env() const {
+      return env_;
+    }
+
+    Environment* const env_;
+    friend class Environment;
+    DISALLOW_COPY_AND_ASSIGN(PersistentHandleCleanup);
+};
+}  // namespace node
+
+#endif  // SRC_PERSISTENT_HANDLE_CLEANUP_H_

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -133,6 +133,7 @@ PipeWrap::PipeWrap(Environment* env,
   int r = uv_pipe_init(env->event_loop(), &handle_, ipc);
   CHECK_EQ(r, 0);  // How do we proxy this error up to javascript?
                    // Suggestion: uv_pipe_init() returns void.
+  RegisterHandleCleanup(reinterpret_cast<uv_handle_t*>(&handle_));
   UpdateWriteQueueSize();
 }
 

--- a/src/producer-consumer-queue.h
+++ b/src/producer-consumer-queue.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2015 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Significant changes made to the software:
+ *
+ * - Removed Boost dependency
+ * - Removed support for storing values directly
+ * - Removed construction and destruction of the queue items feature
+ * - Added initialization of all values to nullptr
+ * - Made size a template parameter
+ * - Crash instead of throw if malloc fails in constructor
+ * - Changed namespace from folly to node
+ * - Removed sizeGuess(), isFull(), isEmpty(), popFront() and frontPtr() methods
+ * - Renamed write() to PushBack(), read() to PopFront()
+ * - Added padding to fields
+ *
+ */
+
+// @author Bo Hu (bhu@fb.com)
+// @author Jordan DeLong (delong.j@fb.com)
+
+#ifndef SRC_PRODUCER_CONSUMER_QUEUE_H_
+#define SRC_PRODUCER_CONSUMER_QUEUE_H_
+
+#include "util.h"
+#include <atomic>
+#include <string.h>
+
+namespace node {
+
+/*
+ * ProducerConsumerQueue is a one producer and one consumer queue
+ * without locks.
+ */
+template<uint32_t size, class T>
+class ProducerConsumerQueue {
+  public:
+    // size must be >= 2.
+    //
+    // Also, note that the number of usable slots in the queue at any
+    // given time is actually (size-1), so if you start with an empty queue,
+    // PushBack will fail after size-1 insertions.
+    ProducerConsumerQueue() : readIndex_(0), writeIndex_(0) {
+      STATIC_ASSERT(size >= 2);
+      memset(&records_, 0, sizeof(records_[0]) * size);
+    }
+
+    ~ProducerConsumerQueue() {
+      while (T* record = PopFront())
+        delete record;
+    }
+
+    // Returns false if the queue is full, cannot insert nullptr
+    bool PushBack(T* item) {
+      CHECK_NE(item, nullptr);
+      auto const currentWrite = writeIndex_.load(std::memory_order_relaxed);
+      auto nextRecord = currentWrite + 1;
+      if (nextRecord == size) {
+        nextRecord = 0;
+      }
+
+      if (nextRecord != readIndex_.load(std::memory_order_acquire)) {
+        records_[currentWrite] = item;
+        writeIndex_.store(nextRecord, std::memory_order_release);
+        return true;
+      }
+
+      // queue is full
+      return false;
+    }
+
+    // Returns nullptr if the queue is empty.
+    T* PopFront() {
+      auto const currentRead = readIndex_.load(std::memory_order_relaxed);
+      if (currentRead == writeIndex_.load(std::memory_order_acquire)) {
+        // queue is empty
+        return nullptr;
+      }
+
+      auto nextRecord = currentRead + 1;
+      if (nextRecord == size) {
+        nextRecord = 0;
+      }
+      T* ret = records_[currentRead];
+      readIndex_.store(nextRecord, std::memory_order_release);
+      CHECK_NE(ret, nullptr);
+      return ret;
+    }
+  private:
+    static const size_t kCacheLineLength = 128;
+    typedef char padding[kCacheLineLength];
+    padding padding1_;
+    T* records_[size];
+    padding padding2_;
+    std::atomic<unsigned int> readIndex_;
+    padding padding3_;
+    std::atomic<unsigned int> writeIndex_;
+    padding padding4_;
+    DISALLOW_COPY_AND_ASSIGN(ProducerConsumerQueue);
+};
+
+}  // namespace node
+
+#endif  // SRC_PRODUCER_CONSUMER_QUEUE_H_

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -58,6 +58,7 @@ class SignalWrap : public HandleWrap {
                    AsyncWrap::PROVIDER_SIGNALWRAP) {
     int r = uv_signal_init(env->event_loop(), &handle_);
     CHECK_EQ(r, 0);
+    RegisterHandleCleanup(reinterpret_cast<uv_handle_t*>(&handle_));
   }
 
   static void Start(const FunctionCallbackInfo<Value>& args) {

--- a/src/smalloc.cc
+++ b/src/smalloc.cc
@@ -1,0 +1,636 @@
+#include "smalloc.h"
+
+#include "env.h"
+#include "env-inl.h"
+#include "node.h"
+#include "node_internals.h"
+#include "v8-profiler.h"
+#include "v8.h"
+
+#include <string.h>
+
+#define EXTERNAL_ARRAY_TYPES(V)                                               \
+  V(Int8, kExternalInt8Array)                                                 \
+  V(Uint8, kExternalUint8Array)                                               \
+  V(Int16, kExternalInt16Array)                                               \
+  V(Uint16, kExternalUint16Array)                                             \
+  V(Int32, kExternalInt32Array)                                               \
+  V(Uint32, kExternalUint32Array)                                             \
+  V(Float, kExternalFloat32Array)                                             \
+  V(Double, kExternalFloat64Array)                                            \
+  V(Uint8Clamped, kExternalUint8ClampedArray)
+
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+
+
+namespace node {
+namespace smalloc {
+
+using v8::Context;
+using v8::External;
+using v8::ExternalArrayType;
+using v8::FunctionCallbackInfo;
+using v8::Handle;
+using v8::HandleScope;
+using v8::HeapProfiler;
+using v8::Isolate;
+using v8::Local;
+using v8::Object;
+using v8::Persistent;
+using v8::RetainedObjectInfo;
+using v8::Uint32;
+using v8::Value;
+using v8::WeakCallbackData;
+using v8::kExternalUint8Array;
+
+
+void CallbackInfo::Free(char* data, void*) {
+  ::free(data);
+}
+
+
+CallbackInfo* CallbackInfo::New(Isolate* isolate,
+                                CallbackInfo::Ownership ownership,
+                                Handle<Object> object,
+                                FreeCallback callback,
+                                void* hint) {
+  return new CallbackInfo(isolate, ownership, object, callback, hint);
+}
+
+
+void CallbackInfo::Dispose(Isolate* isolate) {
+  WeakCallback(isolate, PersistentToLocal(isolate, persistent_));
+}
+
+
+Persistent<Object>* CallbackInfo::persistent() {
+  return &persistent_;
+}
+
+
+CallbackInfo::CallbackInfo(Isolate* isolate,
+                           CallbackInfo::Ownership ownership,
+                           Handle<Object> object,
+                           FreeCallback callback,
+                           void* hint)
+    : ownership_(ownership),
+      persistent_(isolate, object),
+      callback_(callback),
+      hint_(hint) {
+  persistent_.SetWeak(this, WeakCallback);
+  persistent_.SetWrapperClassId(ClassId::SMALLOC);
+  persistent_.MarkIndependent();
+  isolate->AdjustAmountOfExternalAllocatedMemory(sizeof(*this));
+}
+
+
+CallbackInfo::~CallbackInfo() {
+  persistent_.Reset();
+}
+
+
+void CallbackInfo::DisposeNoAllocation(Isolate* isolate) {
+  HandleScope scope(isolate);
+  Local<Object> object = PersistentToLocal(isolate, persistent_);
+  void* array_data = object->GetIndexedPropertiesExternalArrayData();
+  free(array_data);
+  delete this;
+}
+
+
+void CallbackInfo::WeakCallback(
+    const WeakCallbackData<Object, CallbackInfo>& data) {
+  data.GetParameter()->WeakCallback(data.GetIsolate(), data.GetValue());
+}
+
+
+inline size_t InternalExternalArraySize(enum ExternalArrayType type) {
+  switch (type) {
+    case v8::kExternalUint8Array:
+      return sizeof(uint8_t);
+    case v8::kExternalInt8Array:
+      return sizeof(int8_t);
+    case v8::kExternalInt16Array:
+      return sizeof(int16_t);
+    case v8::kExternalUint16Array:
+      return sizeof(uint16_t);
+    case v8::kExternalInt32Array:
+      return sizeof(int32_t);
+    case v8::kExternalUint32Array:
+      return sizeof(uint32_t);
+    case v8::kExternalFloat32Array:
+      return sizeof(float);   // NOLINT(runtime/sizeof)
+    case v8::kExternalFloat64Array:
+      return sizeof(double);  // NOLINT(runtime/sizeof)
+    case v8::kExternalUint8ClampedArray:
+      return sizeof(uint8_t);
+  }
+  return 0;
+}
+
+
+void CallbackInfo::WeakCallback(Isolate* isolate, Local<Object> object) {
+  void* array_data = object->GetIndexedPropertiesExternalArrayData();
+  size_t array_length = object->GetIndexedPropertiesExternalArrayDataLength();
+  enum ExternalArrayType array_type =
+      object->GetIndexedPropertiesExternalArrayDataType();
+  size_t array_size = InternalExternalArraySize(array_type);
+  CHECK_GT(array_size, 0);
+  if (array_size > 1 && array_data != NULL) {
+    CHECK_GT(array_length * array_size, array_length);  // Overflow check.
+    array_length *= array_size;
+  }
+  object->SetIndexedPropertiesToExternalArrayData(nullptr, array_type, 0);
+  callback_(static_cast<char*>(array_data), hint_);
+  int64_t change_in_bytes = -static_cast<int64_t>(sizeof(*this));
+  if (ownership_ == kInternal)
+    change_in_bytes -= static_cast<int64_t>(array_length);
+  isolate->AdjustAmountOfExternalAllocatedMemory(change_in_bytes);
+  delete this;
+}
+
+
+// return size of external array type, or 0 if unrecognized
+size_t ExternalArraySize(enum ExternalArrayType type) {
+  return InternalExternalArraySize(type);
+}
+
+
+// copyOnto(source, source_start, dest, dest_start, copy_length)
+void CopyOnto(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+
+  ASSERT(args[0]->IsObject());
+  ASSERT(args[2]->IsObject());
+
+  Local<Object> source = args[0].As<Object>();
+  Local<Object> dest = args[2].As<Object>();
+
+  ASSERT(source->HasIndexedPropertiesInExternalArrayData());
+  ASSERT(dest->HasIndexedPropertiesInExternalArrayData());
+
+  size_t source_start = args[1]->Uint32Value();
+  size_t dest_start = args[3]->Uint32Value();
+  size_t copy_length = args[4]->Uint32Value();
+  char* source_data = static_cast<char*>(
+      source->GetIndexedPropertiesExternalArrayData());
+  char* dest_data = static_cast<char*>(
+      dest->GetIndexedPropertiesExternalArrayData());
+
+  size_t source_length = source->GetIndexedPropertiesExternalArrayDataLength();
+  enum ExternalArrayType source_type =
+    source->GetIndexedPropertiesExternalArrayDataType();
+  size_t source_size = InternalExternalArraySize(source_type);
+
+  size_t dest_length = dest->GetIndexedPropertiesExternalArrayDataLength();
+  enum ExternalArrayType dest_type =
+    dest->GetIndexedPropertiesExternalArrayDataType();
+  size_t dest_size = InternalExternalArraySize(dest_type);
+
+  // optimization for Uint8 arrays (i.e. Buffers)
+  if (source_size != 1 || dest_size != 1) {
+    if (source_size == 0)
+      return env->ThrowTypeError("unknown source external array type");
+    if (dest_size == 0)
+      return env->ThrowTypeError("unknown dest external array type");
+
+    if (source_length * source_size < source_length)
+      return env->ThrowRangeError("source_length * source_size overflow");
+    if (copy_length * source_size < copy_length)
+      return env->ThrowRangeError("copy_length * source_size overflow");
+    if (dest_length * dest_size < dest_length)
+      return env->ThrowRangeError("dest_length * dest_size overflow");
+
+    source_length *= source_size;
+    copy_length *= source_size;
+    dest_length *= dest_size;
+  }
+
+  // necessary to check in case (source|dest)_start _and_ copy_length overflow
+  if (copy_length > source_length)
+    return env->ThrowRangeError("copy_length > source_length");
+  if (copy_length > dest_length)
+    return env->ThrowRangeError("copy_length > dest_length");
+  if (source_start > source_length)
+    return env->ThrowRangeError("source_start > source_length");
+  if (dest_start > dest_length)
+    return env->ThrowRangeError("dest_start > dest_length");
+
+  // now we can guarantee these will catch oob access and *_start overflow
+  if (source_start + copy_length > source_length)
+    return env->ThrowRangeError("source_start + copy_length > source_length");
+  if (dest_start + copy_length > dest_length)
+    return env->ThrowRangeError("dest_start + copy_length > dest_length");
+
+  memmove(dest_data + dest_start, source_data + source_start, copy_length);
+}
+
+
+// dest will always be same type as source
+// for internal use:
+//    dest._data = sliceOnto(source, dest, start, end);
+void SliceOnto(const FunctionCallbackInfo<Value>& args) {
+  Local<Object> source = args[0].As<Object>();
+  Local<Object> dest = args[1].As<Object>();
+
+  CHECK(source->HasIndexedPropertiesInExternalArrayData());
+  CHECK_EQ(false, dest->HasIndexedPropertiesInExternalArrayData());
+
+  char* source_data = static_cast<char*>(
+      source->GetIndexedPropertiesExternalArrayData());
+  size_t source_len = source->GetIndexedPropertiesExternalArrayDataLength();
+  enum ExternalArrayType source_type =
+    source->GetIndexedPropertiesExternalArrayDataType();
+  size_t source_size = InternalExternalArraySize(source_type);
+
+  CHECK_NE(source_size, 0);
+
+  size_t start = args[2]->Uint32Value();
+  size_t end = args[3]->Uint32Value();
+  size_t length = end - start;
+
+  if (source_size > 1) {
+    CHECK_GE(length * source_size, length);
+    length *= source_size;
+  }
+
+  CHECK(source_data != nullptr || length == 0);
+  CHECK_LE(end, source_len);
+  CHECK_LE(start, end);
+
+  dest->SetIndexedPropertiesToExternalArrayData(source_data + start,
+                                                source_type,
+                                                length);
+  args.GetReturnValue().Set(source);
+}
+
+
+// for internal use:
+//    alloc(obj, n[, type]);
+void Alloc(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+
+  ASSERT(args[0]->IsObject());
+
+  Local<Object> obj = args[0].As<Object>();
+
+  ASSERT(!obj->HasIndexedPropertiesInExternalArrayData());
+
+  size_t length = args[1]->Uint32Value();
+  enum ExternalArrayType array_type;
+
+  // it's faster to not pass the default argument then use Uint32Value
+  if (args[2]->IsUndefined()) {
+    array_type = kExternalUint8Array;
+  } else {
+    array_type = static_cast<ExternalArrayType>(args[2]->Uint32Value());
+    size_t type_length = InternalExternalArraySize(array_type);
+    CHECK_GE(type_length * length, length);
+    length *= type_length;
+  }
+
+  Alloc(env, obj, length, array_type);
+  args.GetReturnValue().Set(obj);
+}
+
+
+void Alloc(Environment* env,
+           Handle<Object> obj,
+           size_t length,
+           enum ExternalArrayType type) {
+  size_t type_size = InternalExternalArraySize(type);
+
+  CHECK_LE(length, kMaxLength);
+  CHECK_GT(type_size, 0);
+
+  if (length == 0)
+    return Alloc(env, obj, nullptr, length, type);
+
+  char* data = static_cast<char*>(malloc(length));
+  if (data == nullptr) {
+    FatalError("node::smalloc::Alloc(node::Environment*, "
+               " v8::Handle<v8::Object>, size_t, v8::ExternalArrayType)",
+               "Out Of Memory");
+    UNREACHABLE();
+  }
+
+  Alloc(env, obj, data, length, type);
+}
+
+
+void Alloc(Environment* env,
+           Handle<Object> obj,
+           char* data,
+           size_t length,
+           enum ExternalArrayType type) {
+  CHECK_EQ(false, obj->HasIndexedPropertiesInExternalArrayData());
+  env->isolate()->AdjustAmountOfExternalAllocatedMemory(length);
+  size_t size = length / InternalExternalArraySize(type);
+  obj->SetIndexedPropertiesToExternalArrayData(data, type, size);
+  CallbackInfo::New(env->isolate(),
+                    CallbackInfo::kInternal,
+                    obj,
+                    CallbackInfo::Free);
+}
+
+
+// for internal use: dispose(obj);
+void AllocDispose(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  AllocDispose(env, args[0].As<Object>());
+}
+
+
+void AllocDispose(Environment* env, Handle<Object> obj) {
+  HandleScope handle_scope(env->isolate());
+
+  if (env->using_smalloc_alloc_cb()) {
+    Local<Value> ext_v = obj->GetHiddenValue(env->smalloc_p_string());
+    if (ext_v->IsExternal()) {
+      Local<External> ext = ext_v.As<External>();
+      CallbackInfo* info = static_cast<CallbackInfo*>(ext->Value());
+      info->Dispose(env->isolate());
+      return;
+    }
+  }
+
+  char* data = static_cast<char*>(obj->GetIndexedPropertiesExternalArrayData());
+  size_t length = obj->GetIndexedPropertiesExternalArrayDataLength();
+  enum ExternalArrayType array_type =
+    obj->GetIndexedPropertiesExternalArrayDataType();
+  size_t array_size = InternalExternalArraySize(array_type);
+
+  CHECK_GT(array_size, 0);
+  CHECK_GE(length * array_size, length);
+
+  length *= array_size;
+
+  if (data != nullptr) {
+    obj->SetIndexedPropertiesToExternalArrayData(nullptr,
+                                                 kExternalUint8Array,
+                                                 0);
+    free(data);
+  }
+  if (length != 0) {
+    int64_t change_in_bytes = -static_cast<int64_t>(length);
+    env->isolate()->AdjustAmountOfExternalAllocatedMemory(change_in_bytes);
+  }
+}
+
+
+static void Alloc(Environment* env,
+                  CallbackInfo::Ownership ownership,
+                  Handle<Object> obj,
+                  char* data,
+                  size_t length,
+                  FreeCallback fn,
+                  void* hint,
+                  enum ExternalArrayType type) {
+  CHECK_EQ(false, obj->HasIndexedPropertiesInExternalArrayData());
+  Isolate* isolate = env->isolate();
+  HandleScope handle_scope(isolate);
+  env->set_using_smalloc_alloc_cb(true);
+  CallbackInfo* info = CallbackInfo::New(isolate, ownership, obj, fn, hint);
+  obj->SetHiddenValue(env->smalloc_p_string(), External::New(isolate, info));
+  size_t size = length / InternalExternalArraySize(type);
+  obj->SetIndexedPropertiesToExternalArrayData(data, type, size);
+}
+
+
+void Alloc(Environment* env,
+           Handle<Object> obj,
+           size_t length,
+           FreeCallback fn,
+           void* hint,
+           enum ExternalArrayType type) {
+  CHECK_LE(length, kMaxLength);
+
+  size_t type_size = InternalExternalArraySize(type);
+
+  CHECK_GT(type_size, 0);
+  CHECK_GE(length * type_size, length);
+
+  length *= type_size;
+
+  char* data = static_cast<char*>(malloc(length));
+  if (data == nullptr) {
+    FatalError("node::smalloc::Alloc(node::Environment*, "
+               " v8::Handle<v8::Object>, size_t, node::FreeCallback,"
+               " void*, v8::ExternalArrayType)", "Out Of Memory");
+    UNREACHABLE();
+  }
+
+  env->isolate()->AdjustAmountOfExternalAllocatedMemory(length);
+  Alloc(env, CallbackInfo::kInternal, obj, data, length, fn, hint, type);
+}
+
+
+void Alloc(Environment* env,
+           Handle<Object> obj,
+           char* data,
+           size_t length,
+           FreeCallback fn,
+           void* hint,
+           enum ExternalArrayType type) {
+  Alloc(env, CallbackInfo::kExternal, obj, data, length, fn, hint, type);
+}
+
+
+void HasExternalData(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  ASSERT(args[0]->IsObject());
+  args.GetReturnValue().Set(HasExternalData(env, args[0].As<Object>()));
+}
+
+
+bool HasExternalData(Environment* env, Local<Object> obj) {
+  return obj->HasIndexedPropertiesInExternalArrayData();
+}
+
+void IsTypedArray(const FunctionCallbackInfo<Value>& args) {
+  args.GetReturnValue().Set(args[0]->IsTypedArray());
+}
+
+void AllocTruncate(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+
+  Local<Object> obj = args[0].As<Object>();
+
+  // can't perform this check in JS
+  if (!obj->HasIndexedPropertiesInExternalArrayData())
+    return env->ThrowTypeError("object has no external array data");
+
+  char* data = static_cast<char*>(obj->GetIndexedPropertiesExternalArrayData());
+  enum ExternalArrayType array_type =
+      obj->GetIndexedPropertiesExternalArrayDataType();
+  int length = obj->GetIndexedPropertiesExternalArrayDataLength();
+
+  unsigned int new_len = args[1]->Uint32Value();
+  if (new_len > kMaxLength)
+    return env->ThrowRangeError("truncate length is bigger than kMaxLength");
+
+  if (static_cast<int>(new_len) > length)
+    return env->ThrowRangeError("truncate length is bigger than current one");
+
+  obj->SetIndexedPropertiesToExternalArrayData(data,
+                                               array_type,
+                                               static_cast<int>(new_len));
+}
+
+
+
+class RetainedAllocInfo: public RetainedObjectInfo {
+ public:
+  explicit RetainedAllocInfo(Handle<Value> wrapper);
+
+  virtual void Dispose() override;
+  virtual bool IsEquivalent(RetainedObjectInfo* other) override;
+  virtual intptr_t GetHash() override;
+  virtual const char* GetLabel() override;
+  virtual intptr_t GetSizeInBytes() override;
+
+ private:
+  static const char label_[];
+  char* data_;
+  int length_;
+};
+
+
+const char RetainedAllocInfo::label_[] = "smalloc";
+
+
+RetainedAllocInfo::RetainedAllocInfo(Handle<Value> wrapper) {
+  Local<Object> obj = wrapper.As<Object>();
+  length_ = obj->GetIndexedPropertiesExternalArrayDataLength();
+  data_ = static_cast<char*>(obj->GetIndexedPropertiesExternalArrayData());
+}
+
+
+void RetainedAllocInfo::Dispose() {
+  delete this;
+}
+
+
+bool RetainedAllocInfo::IsEquivalent(RetainedObjectInfo* other) {
+  return label_ == other->GetLabel() &&
+         data_ == static_cast<RetainedAllocInfo*>(other)->data_;
+}
+
+
+intptr_t RetainedAllocInfo::GetHash() {
+  return reinterpret_cast<intptr_t>(data_);
+}
+
+
+const char* RetainedAllocInfo::GetLabel() {
+  return label_;
+}
+
+
+intptr_t RetainedAllocInfo::GetSizeInBytes() {
+  return length_;
+}
+
+
+RetainedObjectInfo* WrapperInfo(uint16_t class_id, Handle<Value> wrapper) {
+  return new RetainedAllocInfo(wrapper);
+}
+
+
+// User facing API.
+
+void Alloc(Isolate* isolate,
+           Handle<Object> obj,
+           size_t length,
+           enum ExternalArrayType type) {
+  Alloc(Environment::GetCurrent(isolate), obj, length, type);
+}
+
+
+void Alloc(Isolate* isolate,
+           Handle<Object> obj,
+           char* data,
+           size_t length,
+           enum ExternalArrayType type) {
+  Alloc(Environment::GetCurrent(isolate), obj, data, length, type);
+}
+
+
+void Alloc(Isolate* isolate,
+           Handle<Object> obj,
+           size_t length,
+           FreeCallback fn,
+           void* hint,
+           enum ExternalArrayType type) {
+  Alloc(Environment::GetCurrent(isolate), obj, length, fn, hint, type);
+}
+
+
+void Alloc(Isolate* isolate,
+           Handle<Object> obj,
+           char* data,
+           size_t length,
+           FreeCallback fn,
+           void* hint,
+           enum ExternalArrayType type) {
+  Alloc(Environment::GetCurrent(isolate), obj, data, length, fn, hint, type);
+}
+
+
+void AllocDispose(Isolate* isolate, Handle<Object> obj) {
+  AllocDispose(Environment::GetCurrent(isolate), obj);
+}
+
+
+bool HasExternalData(Isolate* isolate, Local<Object> obj) {
+  return HasExternalData(Environment::GetCurrent(isolate), obj);
+}
+
+
+void Initialize(Handle<Object> exports,
+                Handle<Value> unused,
+                Handle<Context> context) {
+  Environment* env = Environment::GetCurrent(context);
+  Isolate* isolate = env->isolate();
+
+  env->SetMethod(exports, "copyOnto", CopyOnto);
+  env->SetMethod(exports, "sliceOnto", SliceOnto);
+
+  env->SetMethod(exports, "alloc", Alloc);
+  env->SetMethod(exports, "dispose", AllocDispose);
+  env->SetMethod(exports, "truncate", AllocTruncate);
+
+  env->SetMethod(exports, "hasExternalData", HasExternalData);
+  env->SetMethod(exports, "isTypedArray", IsTypedArray);
+
+  exports->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kMaxLength"),
+               Uint32::NewFromUnsigned(env->isolate(), kMaxLength));
+
+  Local<Object> types = Object::New(isolate);
+
+  uint32_t kMinType = ~0;
+  uint32_t kMaxType = 0;
+#define V(name, value)                                                        \
+  types->Set(FIXED_ONE_BYTE_STRING(env->isolate(), #name),                    \
+             Uint32::NewFromUnsigned(env->isolate(), v8::value));             \
+  kMinType = MIN(kMinType, static_cast<uint32_t>(v8::value));                 \
+  kMaxType = MAX(kMinType, static_cast<uint32_t>(v8::value));
+  EXTERNAL_ARRAY_TYPES(V)
+#undef V
+
+  exports->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "types"), types);
+  exports->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kMinType"),
+               Uint32::NewFromUnsigned(env->isolate(), kMinType));
+  exports->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "kMaxType"),
+               Uint32::NewFromUnsigned(env->isolate(), kMaxType));
+
+  HeapProfiler* heap_profiler = env->isolate()->GetHeapProfiler();
+  heap_profiler->SetWrapperClassInfoProvider(ClassId::SMALLOC, WrapperInfo);
+}
+
+
+}  // namespace smalloc
+}  // namespace node
+
+NODE_MODULE_CONTEXT_AWARE_BUILTIN(smalloc, node::smalloc::Initialize)

--- a/src/smalloc.h
+++ b/src/smalloc.h
@@ -1,0 +1,181 @@
+#ifndef SRC_SMALLOC_H_
+#define SRC_SMALLOC_H_
+
+#include "node.h"
+#include "v8.h"
+
+namespace node {
+
+// Forward declaration
+class Environment;
+
+/**
+ * Simple memory allocator.
+ *
+ * Utilities for external memory allocation management. Is an abstraction for
+ * v8's external array data handling to simplify and centralize how this is
+ * managed.
+ */
+namespace smalloc {
+
+// mirrors deps/v8/src/objects.h
+static const unsigned int kMaxLength = 0x3fffffff;
+
+NODE_EXTERN typedef void (*FreeCallback)(char* data, void* hint);
+
+/**
+ * Return byte size of external array type.
+ */
+NODE_DEPRECATED(
+    "Use typed arrays",
+    NODE_EXTERN size_t ExternalArraySize(enum v8::ExternalArrayType type));
+
+/**
+ * Allocate external array data onto obj.
+ *
+ * Passed data transfers ownership, and if no callback is passed then memory
+ * will automatically be free'd using free() (not delete[]).
+ *
+ * length is always the byte size of the data. Not the length of the external
+ * array. This intentionally differs from the JS API so users always know
+ * exactly how much memory is being allocated, regardless of the external array
+ * type. For this reason the helper function ExternalArraySize is provided to
+ * help determine the appropriate byte size to be allocated.
+ *
+ * In the following example we're allocating a Float array and setting the
+ * "length" property on the Object:
+ *
+ * \code
+ *    size_t array_length = 8;
+ *    size_t byte_length = node::smalloc::ExternalArraySize(
+ *        v8::kExternalFloatArray);
+ *    v8::Local<v8::Object> obj = v8::Object::New();
+ *    char* data = static_cast<char*>(malloc(byte_length * array_length));
+ *    node::smalloc::Alloc(isolate, obj, data, byte_length,
+ *                         v8::kExternalFloatArray);
+ *    obj->Set(v8::String::NewFromUtf8("length"),
+ *             v8::Integer::NewFromUnsigned(array_length));
+ * \code
+ */
+NODE_DEPRECATED(
+    "Use typed arrays",
+    NODE_EXTERN void Alloc(v8::Isolate* isolate,
+                           v8::Handle<v8::Object> obj,
+                           size_t length,
+                           enum v8::ExternalArrayType type =
+                           v8::kExternalUnsignedByteArray));
+NODE_DEPRECATED(
+    "Use typed arrays",
+    NODE_EXTERN void Alloc(v8::Isolate* isolate,
+                           v8::Handle<v8::Object> obj,
+                           char* data,
+                           size_t length,
+                           enum v8::ExternalArrayType type =
+                           v8::kExternalUnsignedByteArray));
+NODE_DEPRECATED(
+    "Use typed arrays",
+    NODE_EXTERN void Alloc(v8::Isolate* isolate,
+                           v8::Handle<v8::Object> obj,
+                           size_t length,
+                           FreeCallback fn,
+                           void* hint,
+                           enum v8::ExternalArrayType type =
+                           v8::kExternalUnsignedByteArray));
+NODE_DEPRECATED(
+    "Use typed arrays",
+    NODE_EXTERN void Alloc(v8::Isolate* isolate,
+                           v8::Handle<v8::Object> obj,
+                           char* data,
+                           size_t length,
+                           FreeCallback fn,
+                           void* hint,
+                           enum v8::ExternalArrayType type =
+                           v8::kExternalUnsignedByteArray));
+
+/**
+ * Free memory associated with an externally allocated object. If no external
+ * memory is allocated to the object then nothing will happen.
+ */
+NODE_DEPRECATED(
+    "Use typed arrays",
+    NODE_EXTERN void AllocDispose(v8::Isolate* isolate,
+                                  v8::Handle<v8::Object> obj));
+
+
+/**
+ * Check if the Object has externally allocated memory.
+ */
+NODE_DEPRECATED(
+    "Use typed arrays",
+    NODE_EXTERN bool HasExternalData(v8::Isolate* isolate,
+                                     v8::Local<v8::Object> obj));
+
+
+// Internal use
+void Alloc(Environment* env,
+           v8::Handle<v8::Object> obj,
+           size_t length,
+           enum v8::ExternalArrayType type =
+           v8::kExternalUnsignedByteArray);
+void Alloc(Environment* env,
+           v8::Handle<v8::Object> obj,
+           char* data,
+           size_t length,
+           enum v8::ExternalArrayType type =
+           v8::kExternalUnsignedByteArray);
+void Alloc(Environment* env,
+           v8::Handle<v8::Object> obj,
+           size_t length,
+           FreeCallback fn,
+           void* hint,
+           enum v8::ExternalArrayType type =
+           v8::kExternalUnsignedByteArray);
+void Alloc(Environment* env,
+           v8::Handle<v8::Object> obj,
+           char* data,
+           size_t length,
+           FreeCallback fn,
+           void* hint,
+           enum v8::ExternalArrayType type =
+           v8::kExternalUnsignedByteArray);
+void AllocDispose(Environment* env, v8::Handle<v8::Object> obj);
+bool HasExternalData(Environment* env, v8::Local<v8::Object> obj);
+
+class CallbackInfo {
+ public:
+  enum Ownership {
+    kInternal,
+    kExternal
+  };
+
+  static inline void Free(char* data, void* hint);
+  static inline CallbackInfo* New(v8::Isolate* isolate,
+                                  Ownership ownership,
+                                  v8::Handle<v8::Object> object,
+                                  FreeCallback callback,
+                                  void* hint = 0);
+
+  void DisposeNoAllocation(v8::Isolate* isolate);
+  inline void Dispose(v8::Isolate* isolate);
+  inline v8::Persistent<v8::Object>* persistent();
+ private:
+  static void WeakCallback(
+      const v8::WeakCallbackData<v8::Object, CallbackInfo>&);
+  inline void WeakCallback(v8::Isolate* isolate, v8::Local<v8::Object> object);
+  inline CallbackInfo(v8::Isolate* isolate,
+                      Ownership ownership,
+                      v8::Handle<v8::Object> object,
+                      FreeCallback callback,
+                      void* hint);
+  ~CallbackInfo();
+  const Ownership ownership_;
+  v8::Persistent<v8::Object> persistent_;
+  FreeCallback const callback_;
+  void* const hint_;
+  DISALLOW_COPY_AND_ASSIGN(CallbackInfo);
+};
+
+}  // namespace smalloc
+}  // namespace node
+
+#endif  // SRC_SMALLOC_H_

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -191,6 +191,8 @@ void StreamWrap::OnReadImpl(ssize_t nread,
                             void* ctx) {
   StreamWrap* wrap = static_cast<StreamWrap*>(ctx);
   Environment* env = wrap->env();
+  if (!env->CanCallIntoJs())
+    return;
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
 
@@ -232,6 +234,8 @@ void StreamWrap::OnReadCommon(uv_stream_t* handle,
                               const uv_buf_t* buf,
                               uv_handle_type pending) {
   StreamWrap* wrap = static_cast<StreamWrap*>(handle->data);
+  if (!wrap->env()->CanCallIntoJs())
+    return;
   HandleScope scope(wrap->env()->isolate());
   Context::Scope context_scope(wrap->env()->context());
 

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -154,6 +154,7 @@ TCPWrap::TCPWrap(Environment* env, Local<Object> object, AsyncWrap* parent)
   int r = uv_tcp_init(env->event_loop(), &handle_);
   CHECK_EQ(r, 0);  // How do we proxy this error up to javascript?
                    // Suggestion: uv_tcp_init() returns void.
+  RegisterHandleCleanup(reinterpret_cast<uv_handle_t*>(&handle_));
   UpdateWriteQueueSize();
 }
 

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -66,6 +66,7 @@ class TimerWrap : public HandleWrap {
                    AsyncWrap::PROVIDER_TIMERWRAP) {
     int r = uv_timer_init(env->event_loop(), &handle_);
     CHECK_EQ(r, 0);
+    RegisterHandleCleanup(reinterpret_cast<uv_handle_t*>(&handle_));
   }
 
   static void Start(const FunctionCallbackInfo<Value>& args) {

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -134,7 +134,9 @@ TTYWrap::TTYWrap(Environment* env, Local<Object> object, int fd, bool readable)
                  object,
                  reinterpret_cast<uv_stream_t*>(&handle_),
                  AsyncWrap::PROVIDER_TTYWRAP) {
-  uv_tty_init(env->event_loop(), &handle_, fd, readable);
+  int r = uv_tty_init(env->event_loop(), &handle_, fd, readable);
+  CHECK_EQ(r, 0);
+  RegisterHandleCleanup(reinterpret_cast<uv_handle_t*>(&handle_));
 }
 
 }  // namespace node

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -67,6 +67,7 @@ UDPWrap::UDPWrap(Environment* env, Local<Object> object, AsyncWrap* parent)
                  AsyncWrap::PROVIDER_UDPWRAP) {
   int r = uv_udp_init(env->event_loop(), &handle_);
   CHECK_EQ(r, 0);  // can't fail anyway
+  RegisterHandleCleanup(reinterpret_cast<uv_handle_t*>(&handle_));
 }
 
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -3,6 +3,25 @@
 
 namespace node {
 
+char* ToUtf8Value(v8::Isolate* isolate, v8::Local<v8::Value> value) {
+  if (value.IsEmpty())
+    return nullptr;
+
+  v8::Local<v8::String> string_value = value->ToString(isolate);
+  if (string_value.IsEmpty())
+    return nullptr;
+
+  // Allocate enough space to include the null terminator
+  size_t len = StringBytes::StorageSize(isolate, string_value, UTF8) + 1;
+  char* res = static_cast<char*>(malloc(len));
+
+  const int flags =
+      v8::String::NO_NULL_TERMINATION | v8::String::REPLACE_INVALID_UTF8;
+  int length = string_value->WriteUtf8(res, len, 0, flags);
+  res[length] = '\0';
+  return res;
+}
+
 Utf8Value::Utf8Value(v8::Isolate* isolate, v8::Local<v8::Value> value)
     : length_(0), str_(str_st_) {
   if (value.IsEmpty())

--- a/src/util.h
+++ b/src/util.h
@@ -2,6 +2,7 @@
 #define SRC_UTIL_H_
 
 #include "v8.h"
+#include "uv.h"
 
 #include <assert.h>
 #include <stddef.h>
@@ -42,6 +43,8 @@ namespace node {
 #define CHECK_LE(a, b) CHECK((a) <= (b))
 #define CHECK_LT(a, b) CHECK((a) < (b))
 #define CHECK_NE(a, b) CHECK((a) != (b))
+
+#define STATIC_ASSERT(expression) static_assert(expression, #expression)
 
 #define UNREACHABLE() abort()
 
@@ -98,6 +101,7 @@ class ListHead {
   inline void MoveBack(ListHead* that);
   inline void PushBack(T* element);
   inline void PushFront(T* element);
+  inline void Remove(T* element);
   inline bool IsEmpty() const;
   inline T* PopFront();
   inline Iterator begin() const;
@@ -165,8 +169,13 @@ inline void Wrap(v8::Local<v8::Object> object, void* pointer);
 
 inline void ClearWrap(v8::Local<v8::Object> object);
 
+inline void BarrierInitAndWait(uv_barrier_t* barrier, int count);
+inline void BarrierWait(uv_barrier_t* barrier);
+
 template <typename TypeName>
 inline TypeName* Unwrap(v8::Local<v8::Object> object);
+
+char* ToUtf8Value(v8::Isolate* isolate, v8::Handle<v8::Value> value);
 
 class Utf8Value {
   public:

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -1,0 +1,704 @@
+#include "worker.h"
+
+#include "node.h"
+#include "node_internals.h"
+#include "uv.h"
+#include "env.h"
+#include "env-inl.h"
+#include "v8.h"
+#include "libplatform/libplatform.h"
+#include "v8-debug.h"
+#include "util.h"
+#include "util-inl.h"
+#include "producer-consumer-queue.h"
+
+#include <new>
+
+namespace node {
+
+using v8::Handle;
+using v8::Object;
+using v8::FunctionCallbackInfo;
+using v8::Value;
+using v8::String;
+using v8::Boolean;
+using v8::FunctionTemplate;
+using v8::Local;
+using v8::Context;
+using v8::HandleScope;
+using v8::SealHandleScope;
+using v8::Integer;
+using v8::Isolate;
+using v8::Function;
+using v8::Persistent;
+using v8::Locker;
+using v8::TryCatch;
+
+WorkerContext::WorkerContext(Environment* owner_env,
+                             Handle<Object> owner_wrapper,
+                             uv_loop_t* event_loop,
+                             int argc,
+                             const char** argv,
+                             int exec_argc,
+                             const char** exec_argv,
+                             bool keep_alive,
+                             char* user_data,
+                             bool eval)
+    : owner_env_(owner_env),
+      worker_isolate_(nullptr),
+      owner_wrapper_(owner_env->isolate(), owner_wrapper),
+      keep_alive_(keep_alive),
+      user_data_(user_data),
+      eval_(eval),
+      event_loop_(event_loop),
+      owner_notifications_(owner_event_loop(),
+                           OwnerNotificationCallback,
+                           this),
+      worker_notifications_(worker_event_loop(),
+                            WorkerNotificationCallback,
+                            this),
+      argc_(argc),
+      argv_(argv),
+      exec_argc_(exec_argc),
+      exec_argv_(exec_argv) {
+  CHECK_NE(event_loop, nullptr);
+  CHECK_NE(event_loop, uv_default_loop());
+  CHECK_CALLED_FROM_OWNER(this);
+  node::Wrap(owner_wrapper, this);
+
+  owner_env->AddSubWorkerContext(this);
+
+  CHECK_EQ(uv_mutex_init(termination_mutex()), 0);
+  CHECK_EQ(uv_mutex_init(api_mutex()), 0);
+  CHECK_EQ(uv_mutex_init(initialization_mutex()), 0);
+  CHECK_EQ(uv_mutex_init(to_owner_messages_mutex()), 0);
+  CHECK_EQ(uv_mutex_init(to_worker_messages_mutex()), 0);
+}
+
+void WorkerContext::New(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  HandleScope scope(env->isolate());
+  CHECK(args[0]->IsString());
+  CHECK(args[1]->IsObject());
+
+  Local<String> entry_module_path = args[0].As<String>();
+  Local<Object> options = args[1].As<Object>();
+
+#define GET_OPTION(var_name, option_name, Type)                               \
+  Local<Type> var_name;                                                       \
+  {                                                                           \
+    Local<Value> val = options->Get(FIXED_ONE_BYTE_STRING(env->isolate(),     \
+                                                          #option_name));     \
+    var_name = val.As<Type>();                                                \
+  }                                                                           \
+
+  GET_OPTION(keep_alive, keepAlive, Value)
+  GET_OPTION(user_data, userData, String)
+  GET_OPTION(eval, eval, Value)
+#undef GET_OPTION
+
+
+
+  uv_loop_t* worker_event_loop = static_cast<uv_loop_t*>(
+      malloc(sizeof(uv_loop_t)));
+  int err = uv_loop_init(worker_event_loop);
+  if (err != 0) {
+    free(worker_event_loop);
+    return env->ThrowUVException(err, "uv_loop_init");
+  }
+
+  // Heap allocated cause this stack frame can be gone by the time the worker
+  // needs them.
+  int argc = 2;
+  char** argv = new char*[argc];
+  // TODO(petkaantonov) should use correct executable name here
+  argv[0] = const_cast<char*>("node");
+  argv[1] = ToUtf8Value(env->isolate(), entry_module_path);
+  // TODO(petkaantonov) should use the process's real exec args
+  int exec_argc = 0;
+  char** exec_argv = new char*[exec_argc];
+
+  WorkerContext* context =
+      new WorkerContext(env,
+                        args.This(),
+                        worker_event_loop,
+                        argc,
+                        const_cast<const char**>(argv),
+                        exec_argc,
+                        const_cast<const char**>(exec_argv),
+                        keep_alive->BooleanValue(),
+                        ToUtf8Value(env->isolate(), user_data),
+                        eval->BooleanValue());
+
+  err = uv_thread_create(context->worker_thread(), RunWorkerThread, context);
+
+  if (err != 0) {
+    context->worker_notifications()->Dispose();
+    context->Dispose();
+    CHECK_EQ(uv_loop_close(worker_event_loop), 0);
+    free(worker_event_loop);
+    return env->ThrowUVException(err, "uv_thread_create");
+  }
+}
+
+void WorkerContext::PostMessageToOwner(WorkerMessage* message) {
+  if (termination_kind() != NONE) {
+    delete message;
+    return;
+  }
+
+  if (!to_owner_messages_primary_.PushBack(message)) {
+    ScopedLock::Mutex lock(to_owner_messages_mutex());
+    to_owner_messages_backup_.PushBack(message);
+  }
+  owner_notifications()->Notify();
+}
+
+void WorkerContext::PostMessageToOwner(
+    const FunctionCallbackInfo<Value>& args) {
+  CHECK_EQ(args.Length(), 3);
+  WorkerContext* context = node::Unwrap<WorkerContext>(args.Holder());
+  if (context == nullptr)
+    return;
+  CHECK_CALLED_FROM_WORKER(context);
+  CHECK(args[0]->IsString());
+  // transferList ignored for now
+  CHECK(args[1]->IsArray());
+  CHECK(args[2]->IsInt32());
+  Local<String> json = args[0].As<String>();
+  WorkerMessageType message_type =
+      static_cast<WorkerMessageType>(args[2]->Int32Value());
+  WorkerMessage* message =
+      new WorkerMessage(ToUtf8Value(context->worker_env()->isolate(), json),
+                        message_type);
+  context->PostMessageToOwner(message);
+}
+
+void WorkerContext::PostMessageToWorker(WorkerMessage* message) {
+  if (termination_kind() != NONE) {
+    delete message;
+    return;
+  }
+
+  if (!to_worker_messages_primary_.PushBack(message)) {
+    ScopedLock::Mutex lock(to_worker_messages_mutex());
+    to_worker_messages_backup_.PushBack(message);
+  }
+
+  worker_notifications()->Notify();
+}
+
+void WorkerContext::PostMessageToWorker(
+    const FunctionCallbackInfo<Value>& args) {
+  WorkerContext* context = node::Unwrap<WorkerContext>(args.Holder());
+  if (context == nullptr)
+    return;
+  CHECK_CALLED_FROM_OWNER(context);
+  CHECK(args[0]->IsString());
+  // transferList ignored for now
+  CHECK(args[1]->IsArray());
+  CHECK(args[2]->IsInt32());
+  Local<String> json = args[0].As<String>();
+  WorkerMessageType message_type =
+      static_cast<WorkerMessageType>(args[2]->Int32Value());
+  Environment* env = Environment::GetCurrent(args);
+  WorkerMessage* message = new WorkerMessage(ToUtf8Value(env->isolate(),
+                                                         json),
+                                             message_type);
+  context->PostMessageToWorker(message);
+}
+
+void WorkerContext::WrapperNew(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args.GetIsolate());
+  if (!args.IsConstructCall())
+    return env->ThrowError("Illegal invocation");
+  if (args.Length() < 1)
+    return env->ThrowError("entryModulePath is required");
+
+  Local<Object> recv = args.Holder();
+  Local<Function> init = recv->Get(env->worker_init_symbol()).As<Function>();
+  CHECK(init->IsFunction());
+  Local<Value>* argv = new Local<Value>[args.Length()];
+  for (int i = 0; i < args.Length(); ++i)
+    argv[i] = args[i];
+  init->Call(recv, args.Length(), argv);
+  delete[] argv;
+}
+
+void WorkerContext::Initialize(Handle<Object> target,
+                        Handle<Value> unused,
+                        Handle<Context> context) {
+  Environment* env = Environment::GetCurrent(context);
+  if (!node::experimental_workers)
+    return env->ThrowError("Experimental workers are not enabled");
+
+  Local<FunctionTemplate> t = env->NewFunctionTemplate(WorkerContext::New);
+  t->InstanceTemplate()->SetInternalFieldCount(1);
+  t->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "WorkerBinding"));
+
+  env->SetProtoMethod(t, "terminate", Terminate);
+  env->SetProtoMethod(t, "postMessage", PostMessageToWorker);
+  env->SetProtoMethod(t, "ref", Ref);
+  env->SetProtoMethod(t, "unref", Unref);
+
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "WorkerContext"),
+              t->GetFunction());
+
+#define EXPORT_MESSAGE_TYPE(type)                                             \
+  do {                                                                        \
+  target->ForceSet(FIXED_ONE_BYTE_STRING(env->isolate(), #type),              \
+                   Integer::New(env->isolate(),                               \
+                                static_cast<int>(WorkerMessageType::type)),   \
+                   v8::ReadOnly);                                             \
+  } while (0);
+  WORKER_MESSAGE_TYPES(EXPORT_MESSAGE_TYPE)
+#undef EXPORT_MESSAGE_TYPE
+
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "initSymbol"),
+              env->worker_init_symbol());
+
+  Local<FunctionTemplate> ctor_t =
+      FunctionTemplate::New(env->isolate(), WorkerContext::WrapperNew);
+  ctor_t->SetClassName(FIXED_ONE_BYTE_STRING(env->isolate(), "Worker"));
+  ctor_t->SetLength(1);
+  ctor_t->GetFunction()->SetName(
+      FIXED_ONE_BYTE_STRING(env->isolate(), "Worker"));
+
+  target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "JsConstructor"),
+              ctor_t->GetFunction());
+
+
+  if (env->is_worker_thread()) {
+    Local<FunctionTemplate> t = FunctionTemplate::New(env->isolate());
+    t->InstanceTemplate()->SetInternalFieldCount(1);
+    Local<Object> worker_wrapper = t->GetFunction()->NewInstance();
+
+    node::Wrap<WorkerContext>(worker_wrapper, env->worker_context());
+    env->worker_context()->set_worker_wrapper(worker_wrapper);
+
+    env->SetMethod(worker_wrapper,
+                   "_postMessage",
+                   PostMessageToOwner);
+
+    target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "workerWrapper"),
+                worker_wrapper);
+  }
+}
+
+bool WorkerContext::LoopWouldEnd() {
+  CHECK_CALLED_FROM_WORKER(this);
+  bool is_not_terminated;
+  {
+    ScopedLock::Mutex lock(termination_mutex());
+    is_not_terminated = termination_kind() == NONE;
+  }
+
+  if (is_not_terminated) {
+    CHECK_NE(worker_env(), nullptr);
+    node::EmitBeforeExit(worker_env());
+    {
+      ScopedLock::Mutex lock(termination_mutex());
+      if (termination_kind() == NONE) {
+        lock.unlock();
+        bool ret = uv_loop_alive(worker_event_loop());
+          if (uv_run(worker_event_loop(), UV_RUN_NOWAIT))
+            ret = termination_kind() == NONE;
+        return ret;
+      }
+    }
+  }
+  return false;
+}
+
+void WorkerContext::LoopEnded() {
+  CHECK_CALLED_FROM_WORKER(this);
+  ScopedLock::Mutex lock(termination_mutex());
+
+  if (termination_kind() == NONE) {
+    CHECK_NE(worker_env(), nullptr);
+    set_termination_kind(NORMAL);
+    lock.unlock();
+    int exit_code = node::EmitExit(worker_env_);
+    set_exit_code(exit_code);
+    DisposeWorker(NORMAL);
+  } else if (termination_kind() == ABRUPT) {
+    lock.unlock();
+    DisposeWorker(ABRUPT);
+  }
+}
+
+void WorkerContext::Ref(const FunctionCallbackInfo<Value>& args) {
+  WorkerContext* context = node::Unwrap<WorkerContext>(args.Holder());
+  if (context == nullptr)
+    return;
+  CHECK_CALLED_FROM_OWNER(context);
+  context->owner_notifications()->Ref();
+}
+
+void WorkerContext::Unref(const FunctionCallbackInfo<Value>& args) {
+  WorkerContext* context = node::Unwrap<WorkerContext>(args.Holder());
+  if (context == nullptr)
+    return;
+  CHECK_CALLED_FROM_OWNER(context);
+  context->owner_notifications()->Unref();
+}
+
+void WorkerContext::Exit(int exit_code) {
+  CHECK_CALLED_FROM_WORKER(this);
+  CHECK(is_initialized());
+
+  set_exit_code(exit_code);
+  ScopedLock::Mutex lock(termination_mutex());
+
+  if (termination_kind() != NONE)
+    return;
+
+  set_termination_kind(ABRUPT);
+  worker_notifications()->Unref();
+  uv_stop(worker_event_loop());
+  worker_isolate()->TerminateExecution();
+}
+
+void WorkerContext::Terminate(const FunctionCallbackInfo<Value>& args) {
+  WorkerContext* context = node::Unwrap<WorkerContext>(args.Holder());
+  if (context == nullptr)
+    return;
+  context->Terminate();
+}
+
+void WorkerContext::Terminate(bool should_emit_exit_event) {
+  CHECK_CALLED_FROM_OWNER(this);
+  ScopedLock::Mutex init_lock(initialization_mutex());
+  ScopedLock::Mutex api_lock(api_mutex());
+  ScopedLock::Mutex term_lock(termination_mutex());
+
+  if (termination_kind() != NONE)
+    return;
+
+  set_termination_kind(ABRUPT);
+
+  if (is_initialized()) {
+    should_emit_exit_event_ = should_emit_exit_event;
+    worker_isolate()->TerminateExecution();
+    worker_notifications()->Notify();
+  }
+}
+
+bool WorkerContext::ProcessMessageToWorker(Isolate* isolate,
+                                           WorkerMessage* message) {
+  Local<Value> argv[] = {
+    String::NewFromUtf8(isolate, message->payload()),
+    Integer::New(isolate, message->type())
+  };
+  delete message;
+  MakeCallback(isolate,
+               worker_wrapper(),
+               "_onmessage",
+               ARRAY_SIZE(argv),
+               argv);
+  return worker_env()->CanCallIntoJs();
+}
+
+void WorkerContext::ProcessMessagesToWorker() {
+  CHECK_CALLED_FROM_WORKER(this);
+
+  Isolate* isolate = worker_env()->isolate();
+  HandleScope scope(isolate);
+  Context::Scope context_scope(worker_env()->context());
+
+  flush_primary_queue:
+  uint32_t messages_processed = 0;
+  while (WorkerMessage* message = to_worker_messages_primary_.PopFront()) {
+    if (!ProcessMessageToWorker(isolate, message))
+      return;
+    messages_processed++;
+  }
+
+  if (messages_processed >= kMaxPrimaryQueueMessages) {
+    while (true) {
+      WorkerMessage* message = nullptr;
+      {
+        ScopedLock::Mutex lock(to_worker_messages_mutex());
+        message = to_worker_messages_backup_.PopFront();
+      }
+
+      if (message == nullptr)
+        goto flush_primary_queue;
+
+      if (!ProcessMessageToWorker(isolate, message))
+        return;
+    }
+  }
+}
+
+bool WorkerContext::ProcessMessageToOwner(Isolate* isolate,
+                                          WorkerMessage* message) {
+  Local<Value> argv[] = {
+    String::NewFromUtf8(isolate, message->payload()),
+    Integer::New(isolate, message->type())
+  };
+  delete message;
+  MakeCallback(isolate,
+               owner_wrapper(),
+               "_onmessage",
+               ARRAY_SIZE(argv),
+               argv);
+  return owner_env()->CanCallIntoJs();
+}
+
+void WorkerContext::ProcessMessagesToOwner() {
+  CHECK_CALLED_FROM_OWNER(this);
+  Isolate* isolate = owner_env()->isolate();
+  HandleScope scope(isolate);
+  Context::Scope context_scope(owner_env()->context());
+
+  flush_primary_queue:
+  uint32_t messages_processed = 0;
+  while (WorkerMessage* message = to_owner_messages_primary_.PopFront()) {
+    if (!ProcessMessageToOwner(isolate, message))
+      return;
+    messages_processed++;
+  }
+
+  if (messages_processed >= kMaxPrimaryQueueMessages) {
+    while (true) {
+      WorkerMessage* message = nullptr;
+      {
+        ScopedLock::Mutex lock(to_owner_messages_mutex());
+        message = to_owner_messages_backup_.PopFront();
+      }
+
+      if (message == nullptr)
+        goto flush_primary_queue;
+
+      if (!ProcessMessageToOwner(isolate, message))
+        return;
+    }
+  }
+}
+
+void WorkerContext::Dispose() {
+  CHECK_CALLED_FROM_OWNER(this);
+
+  owner_notifications()->Dispose();
+
+  node::ClearWrap(owner_wrapper());
+  owner_wrapper_.Reset();
+
+  uv_mutex_destroy(termination_mutex());
+  uv_mutex_destroy(api_mutex());
+  uv_mutex_destroy(initialization_mutex());
+  uv_mutex_destroy(to_owner_messages_mutex());
+  uv_mutex_destroy(to_worker_messages_mutex());
+
+  delete[] argv_;
+  delete[] exec_argv_;
+
+  while (WorkerMessage* message = to_worker_messages_backup_.PopFront())
+    delete message;
+  while (WorkerMessage* message = to_owner_messages_backup_.PopFront())
+    delete message;
+
+  owner_env()->RemoveSubWorkerContext(this);
+  // Deleting WorkerContexts in response to their notification signals
+  // will cause use-after-free inside libuv. So the final `delete this`
+  // call must be made somewhere else.
+  node::QueueWorkerContextCleanup(this);
+}
+
+void WorkerContext::DisposeWorker(TerminationKind termination_kind) {
+  CHECK_CALLED_FROM_WORKER(this);
+  CHECK(termination_kind != NONE);
+
+  if (worker_env() != nullptr) {
+    worker_env()->TerminateSubWorkers();
+    worker_env()->CleanupHandles();
+    if (!worker_wrapper_.IsEmpty()) {
+      node::ClearWrap(worker_wrapper());
+      worker_wrapper_.Reset();
+    } else {
+      CHECK(termination_kind == ABRUPT);
+    }
+  }
+
+  worker_notifications()->Dispose();
+
+  if (worker_env() != nullptr) {
+    worker_env()->Dispose();
+    worker_env_ = nullptr;
+  }
+  pending_owner_cleanup_ = true;
+  owner_notifications()->Notify();
+}
+
+void WorkerContext::WorkerNotificationCallback(void* arg) {
+  WorkerContext* context = static_cast<WorkerContext*>(arg);
+  CHECK_CALLED_FROM_WORKER(context);
+  if (context->termination_kind() == NONE)
+      context->ProcessMessagesToWorker();
+  else
+      uv_stop(context->worker_event_loop());
+}
+
+void WorkerContext::OwnerNotificationCallback(void* arg) {
+  WorkerContext* context = static_cast<WorkerContext*>(arg);
+  CHECK_CALLED_FROM_OWNER(context);
+  if (context->owner_env()->CanCallIntoJs())
+    context->ProcessMessagesToOwner();
+  context->DisposeIfNecessary();
+}
+
+void WorkerContext::DisposeIfNecessary() {
+  CHECK_CALLED_FROM_OWNER(this);
+  if (pending_owner_cleanup_) {
+    pending_owner_cleanup_ = false;
+    uv_thread_join(worker_thread());
+    int loop_was_not_empty = uv_loop_close(worker_event_loop());
+    // TODO(petkaantonov) replace this with a message that also reports
+    // what is still on the loop if https://github.com/libuv/libuv/pull/291
+    // is accepted.
+    CHECK(!loop_was_not_empty);
+    free(worker_event_loop());
+    event_loop_ = nullptr;
+
+    if (should_emit_exit_event_) {
+      Environment* env = owner_env();
+      HandleScope scope(env->isolate());
+      Context::Scope context_scope(env->context());
+      Local<Value> argv[] = {
+        Integer::New(env->isolate(), exit_code())
+      };
+      MakeCallback(env->isolate(),
+                   owner_wrapper(),
+                   "_onexit",
+                   ARRAY_SIZE(argv),
+                   argv);
+    }
+    Dispose();
+  }
+}
+
+void WorkerContext::Run() {
+  CHECK_CALLED_FROM_WORKER(this);
+
+  if (!keep_alive_)
+    worker_notifications()->Unref();
+
+  Isolate::CreateParams params;
+  ArrayBufferAllocator array_buffer_allocator;
+  params.array_buffer_allocator = &array_buffer_allocator;
+  worker_isolate_ = Isolate::New(params);
+  {
+    ScopedLock::Mutex lock(initialization_mutex());
+    if (!JsExecutionAllowed()) {
+      DisposeWorker(ABRUPT);
+    } else {
+      Isolate::Scope isolate_scope(worker_isolate());
+      Locker locker(worker_isolate());
+
+      // Based on the lowest common denominator, OS X, where
+      // pthreads get by default 512kb of stack space.
+      // On Linux it is 2MB and on Windows 1MB.
+      static const size_t kStackSize = 512 * 1024;
+      // Currently a multiplier of 2 is enough but I left some room to grow.
+      static const size_t kStackAlreadyUsedGuess = 8 * 1024;
+      uint32_t stack_pointer_source;
+      uintptr_t stack_limit = reinterpret_cast<uintptr_t>(
+          &stack_pointer_source - ((kStackSize - kStackAlreadyUsedGuess) /
+                                  sizeof(stack_pointer_source)));
+      worker_isolate()->SetStackLimit(stack_limit);
+
+      HandleScope handle_scope(worker_isolate());
+      Local<Context> context = Context::New(worker_isolate());
+      Context::Scope context_scope(context);
+      Environment* env = node::CreateEnvironment(worker_isolate(),
+                                                 context,
+                                                 this);
+      node::LoadEnvironment(env);
+
+      Local<Value> user_data =
+          v8::JSON::Parse(String::NewFromUtf8(worker_isolate(), user_data_));
+      free(user_data_);
+      user_data_ = nullptr;
+      env->process_object()->ForceSet(FIXED_ONE_BYTE_STRING(worker_isolate(),
+                                                            "workerData"),
+                                      user_data,
+                                      v8::ReadOnly);
+
+      if (eval_) {
+        Local<String> eval_string = String::NewFromUtf8(worker_isolate(),
+                                                        argv_[1]);
+        env->process_object()->ForceSet(FIXED_ONE_BYTE_STRING(worker_isolate(),
+                                                            "_eval"),
+                                        eval_string,
+                                        v8::ReadOnly);
+      }
+
+      Local<Function> entry =
+          env->process_object()->Get(
+              FIXED_ONE_BYTE_STRING(env->isolate(), "_runMain")).As<Function>();
+      set_initialized();
+      // Must not hold any locks when calling into JS
+      lock.unlock();
+      entry->Call(env->process_object(), 0, nullptr);
+      SealHandleScope seal(worker_isolate());
+      bool more;
+      {
+        do {
+          v8::platform::PumpMessageLoop(platform(), worker_isolate());
+          env->ProcessNotifications();
+          more = uv_run(worker_event_loop(), UV_RUN_ONCE);
+          if (!more) {
+            v8::platform::PumpMessageLoop(platform(), worker_isolate());
+            more = LoopWouldEnd();
+          }
+        } while (more && JsExecutionAllowed());
+      }
+      env->set_trace_sync_io(false);
+      LoopEnded();
+    }
+  }
+  worker_isolate()->Dispose();
+  worker_isolate_ = nullptr;
+}
+
+// Entry point for worker_context instance threads
+void WorkerContext::RunWorkerThread(void* arg) {
+  static_cast<WorkerContext*>(arg)->Run();
+}
+
+void WorkerContext::set_worker_wrapper(Local<Object> worker_wrapper) {
+  CHECK_CALLED_FROM_WORKER(this);
+  new(&worker_wrapper_) Persistent<Object>(worker_env()->isolate(),
+                                            worker_wrapper);
+}
+
+Local<Object> WorkerContext::owner_wrapper() {
+  CHECK_CALLED_FROM_OWNER(this);
+  return node::PersistentToLocal(owner_env()->isolate(), owner_wrapper_);
+}
+
+Local<Object> WorkerContext::worker_wrapper() {
+  CHECK_CALLED_FROM_WORKER(this);
+  return node::PersistentToLocal(worker_env()->isolate(), worker_wrapper_);
+}
+
+uv_loop_t* WorkerContext::owner_event_loop() const {
+  return owner_env()->event_loop();
+}
+
+uv_thread_t* WorkerContext::owner_thread() {
+  if (owner_env()->is_worker_thread())
+    return owner_env()->worker_context()->worker_thread();
+  else
+    return main_thread();
+}
+
+v8::Platform* WorkerContext::platform() {
+  return node::default_platform;
+}
+
+}  // namespace node
+
+NODE_MODULE_CONTEXT_AWARE_BUILTIN(worker_context,
+                                  node::WorkerContext::Initialize)

--- a/src/worker.h
+++ b/src/worker.h
@@ -1,0 +1,289 @@
+#ifndef SRC_WORKER_H_
+#define SRC_WORKER_H_
+
+#include "util.h"
+#include "util-inl.h"
+#include "notification-channel.h"
+#include "producer-consumer-queue.h"
+
+#include "uv.h"
+#include "v8.h"
+
+#ifndef NODE_OS_MACOSX
+  #define CHECK_CALLED_FROM_OWNER(worker_context)                              \
+    do {                                                                       \
+      uv_thread_t self = uv_thread_self();                                     \
+      CHECK(uv_thread_equal(&self, worker_context->owner_thread()));           \
+    } while (0);                                                               \
+
+  #define CHECK_CALLED_FROM_WORKER(worker_context)                             \
+    do {                                                                       \
+      uv_thread_t self = uv_thread_self();                                     \
+      CHECK(uv_thread_equal(&self, worker_context->worker_thread()));          \
+    } while (0);                                                               \
+
+#else
+  #define CHECK_CALLED_FROM_OWNER(worker_context)
+  #define CHECK_CALLED_FROM_WORKER(worker_context)
+#endif  // NODE_OS_MACOSX
+
+#define WORKER_MESSAGE_TYPES(V)                                               \
+  V(USER)                                                                     \
+  V(INTERNAL)                                                                 \
+  V(EXCEPTION)                                                                \
+
+namespace node {
+class Environment;
+class WorkerContext;
+
+enum WorkerMessageType {
+#define DECLARE_ENUM_ITEM(type) type,
+  WORKER_MESSAGE_TYPES(DECLARE_ENUM_ITEM)
+#undef DECLARE_ENUM_ITEM
+};
+
+class WorkerMessage {
+  public:
+    WorkerMessage(char* payload,
+                  WorkerMessageType message_type = WorkerMessageType::USER)
+        : payload_(payload), message_type_(message_type) {
+    }
+
+    ~WorkerMessage() {
+      free(payload_);
+    }
+
+    char* payload() const {
+      return payload_;
+    }
+
+    WorkerMessageType type() const {
+      return message_type_;
+    }
+
+    ListNode<WorkerMessage> member;
+  private:
+    char* const payload_;
+    WorkerMessageType message_type_;
+
+    friend class WorkerContext;
+};
+
+typedef ListHead<WorkerMessage, &WorkerMessage::member> WorkerMessageList;
+// Terms:
+// 'owner' the environment of this worker's owner. Can run in main thread but
+// a worker can also own other workers.
+// 'worker' the environment of this worker. Cannot run in main thread.
+class WorkerContext {
+  public:
+    WorkerContext(Environment* env,
+           v8::Handle<v8::Object> owner_wrapper,
+           uv_loop_t* event_loop,
+           int argc,
+           const char** argv,
+           int exec_argc,
+           const char** exec_argv,
+           bool keep_alive,
+           char* user_data,
+           bool eval);
+    static void Initialize(v8::Handle<v8::Object> target,
+                           v8::Handle<v8::Value> unused,
+                           v8::Handle<v8::Context> context);
+    static void RunWorkerThread(void* arg);
+
+    bool IsTerminated() {
+      return termination_kind() != NONE;
+    }
+
+    uv_loop_t* worker_event_loop() const {
+      return event_loop_;
+    }
+
+    int argc() const {
+      return argc_;
+    }
+
+    const char** argv() const {
+      return argv_;
+    }
+
+    int exec_argc() const {
+      return exec_argc_;
+    }
+
+    const char** exec_argv() const {
+      return exec_argv_;
+    }
+
+    uv_mutex_t* api_mutex() {
+      return &api_mutex_;
+    }
+
+    ListNode<WorkerContext> subworker_list_member_;
+    ListNode<WorkerContext> cleanup_queue_member_;
+  private:
+    enum TerminationKind { NONE, NORMAL, ABRUPT };
+    bool JsExecutionAllowed() const {
+      return termination_kind() != ABRUPT;
+    }
+
+    void NotifyWorker();
+    void NotifyOwner();
+    void Run();
+    void LoopEnded();
+    bool LoopWouldEnd();
+    void ProcessMessagesToOwner();
+    bool ProcessMessageToOwner(v8::Isolate* isolate, WorkerMessage* message);
+    void ProcessMessagesToWorker();
+    bool ProcessMessageToWorker(v8::Isolate* isolate, WorkerMessage* message);
+    void PostMessageToOwner(WorkerMessage* message);
+    void PostMessageToWorker(WorkerMessage* message);
+    void Exit(int exit_code);
+    void Terminate(bool should_emit_exit_event = true);
+    void DisposeIfNecessary();
+    void DidTerminateAbruptly();
+    void DisposeWorker(TerminationKind kind);
+    void Dispose();
+    static void WorkerNotificationCallback(void* arg);
+    static void OwnerNotificationCallback(void* arg);
+    static WorkerContext* Unwrap(
+        const v8::FunctionCallbackInfo<v8::Value>& args);
+    static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
+    static void WrapperNew(const v8::FunctionCallbackInfo<v8::Value>& args);
+    static void PostMessageToOwner(
+        const v8::FunctionCallbackInfo<v8::Value>& args);
+    static void PostMessageToWorker(
+        const v8::FunctionCallbackInfo<v8::Value>& args);
+    static void Terminate(const v8::FunctionCallbackInfo<v8::Value>& args);
+    static void NoKeepAlive(const v8::FunctionCallbackInfo<v8::Value>& args);
+    static void Ref(const v8::FunctionCallbackInfo<v8::Value>& args);
+    static void Unref(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+    v8::Platform* platform();
+
+    uv_mutex_t* termination_mutex() {
+      return &termination_mutex_;
+    }
+
+    uv_mutex_t* initialization_mutex() {
+      return &initialization_mutex_;
+    }
+
+    uv_thread_t* worker_thread() {
+      return &thread_;
+    }
+
+    uv_thread_t* owner_thread();
+
+    uv_mutex_t* to_owner_messages_mutex() {
+      return &to_owner_messages_mutex_;
+    }
+
+    uv_mutex_t* to_worker_messages_mutex() {
+      return &to_worker_messages_mutex_;
+    }
+
+    NotificationChannel* owner_notifications() {
+      return &owner_notifications_;
+    }
+
+    NotificationChannel* worker_notifications() {
+      return &worker_notifications_;
+    }
+
+    int exit_code() const {
+      return exit_code_;
+    }
+
+    void set_exit_code(int exit_code) {
+      exit_code_ = exit_code;
+    }
+
+    void set_initialized() {
+      is_initialized_ = true;
+    }
+
+    TerminationKind termination_kind() const {
+      return termination_kind_;
+    }
+
+    void set_termination_kind(TerminationKind kind) {
+      termination_kind_ = kind;
+    }
+
+    void set_worker_wrapper(v8::Local<v8::Object> worker_wrapper);
+
+    uv_loop_t* owner_event_loop() const;
+
+    Environment* worker_env() const {
+      return worker_env_;
+    }
+
+    Environment* owner_env() const {
+      return owner_env_;
+    }
+
+    void set_worker_env(Environment* worker_env) {
+      CHECK_NE(worker_env, nullptr);
+      CHECK_EQ(worker_env_, nullptr);
+      worker_env_ = worker_env;
+    }
+
+    bool is_initialized() const {
+      return is_initialized_;
+    }
+
+    v8::Isolate* worker_isolate() const {
+      return worker_isolate_;
+    }
+
+    // The JS object in the owner thread that wraps this WorkerContext.
+    v8::Local<v8::Object> owner_wrapper();
+    // The JS object in the worker thread that wraps this WorkerContext.
+    v8::Local<v8::Object> worker_wrapper();
+
+    static const uint32_t kPrimaryQueueSize = 2048;
+    static const uint32_t kMaxPrimaryQueueMessages = kPrimaryQueueSize - 1;
+
+    Environment* const owner_env_;
+    Environment* worker_env_ = nullptr;
+    v8::Isolate* worker_isolate_;
+    v8::Persistent<v8::Object> owner_wrapper_;
+    v8::Persistent<v8::Object> worker_wrapper_;
+
+    bool const keep_alive_ = true;
+    char* user_data_ = nullptr;
+    bool const eval_ = false;
+
+    uv_loop_t* event_loop_;
+    uv_thread_t thread_;
+    uv_mutex_t termination_mutex_;
+    uv_mutex_t api_mutex_;
+    uv_mutex_t initialization_mutex_;
+    uv_mutex_t to_owner_messages_mutex_;
+    uv_mutex_t to_worker_messages_mutex_;
+    NotificationChannel owner_notifications_;
+    NotificationChannel worker_notifications_;
+    bool is_initialized_ = false;
+    bool pending_owner_cleanup_ = false;
+    bool should_emit_exit_event_ = true;
+    TerminationKind termination_kind_ = NONE;
+    int exit_code_ = 0;
+    int const argc_;
+    const char** const argv_;
+    int const exec_argc_;
+    const char** const exec_argv_;
+
+    ProducerConsumerQueue<kPrimaryQueueSize,
+                          WorkerMessage> to_owner_messages_primary_;
+    ProducerConsumerQueue<kPrimaryQueueSize,
+                          WorkerMessage> to_worker_messages_primary_;
+    WorkerMessageList to_owner_messages_backup_;
+    WorkerMessageList to_worker_messages_backup_;
+
+    friend class Environment;
+};
+
+}  // namespace node
+
+#endif  // SRC_WORKER_H_

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -260,7 +260,10 @@ assert.equal(util.inspect(map, true),
 
 // test Promise
 assert.equal(util.inspect(Promise.resolve(3)), 'Promise { 3 }');
-assert.equal(util.inspect(Promise.reject(3)), 'Promise { <rejected> 3 }');
+var rejectedPromise = Promise.reject(3);
+// Handle rejection.
+rejectedPromise.catch(function() {});
+assert.equal(util.inspect(rejectedPromise), 'Promise { <rejected> 3 }');
 assert.equal(util.inspect(new Promise(function() {})), 'Promise { <pending> }');
 var promise = Promise.resolve('foo');
 promise.bar = 42;

--- a/test/workers/test-api.js
+++ b/test/workers/test-api.js
@@ -1,0 +1,53 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var Worker = require('worker');
+var checks = 0;
+
+if (process.isMainThread) {
+  try {
+    Worker();
+  } catch (e) {checks++;}
+
+  try {
+    Worker(1);
+  } catch (e) {checks++;}
+
+  try {
+    Worker('str');
+  } catch (e) {checks++;}
+
+  try {
+    new Worker();
+  } catch (e) {checks++;}
+
+  try {
+    new Worker(1);
+  } catch (e) {checks++;}
+
+  var aWorker = new Worker(__filename, {keepAlive: false});
+
+  aWorker.postMessage({hello: 'world'});
+  aWorker.on('message', function(data) {
+    assert.deepEqual({hello: 'world'}, data);
+    checks++;
+  });
+  aWorker.on('exit', function() {
+    checks++;
+    try {
+      aWorker.postMessage([]);
+    } catch (e) {checks++;}
+    try {
+      aWorker.terminate();
+    } catch (e) {checks++;}
+  });
+  process.on('beforeExit', function() {
+    assert.equal(9, checks);
+  });
+} else {
+  Worker.on('message', function(data) {
+    assert.deepEqual({hello: 'world'}, data);
+    Worker.postMessage({hello: 'world'});
+  });
+}

--- a/test/workers/test-child-process.js
+++ b/test/workers/test-child-process.js
@@ -1,0 +1,66 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var util = require('util');
+var Worker = require('worker');
+var common = require('../common');
+var checks = 0;
+var tests = [
+  'test/parallel/test-child-process-buffering.js',
+  'test/parallel/test-child-process-cwd.js',
+  // Workers cannot mutate environment variables
+  //'test/parallel/test-child-process-default-options.js',
+  'test/parallel/test-child-process-detached.js',
+  'test/parallel/test-child-process-disconnect.js',
+  'test/parallel/test-child-process-double-pipe.js',
+  'test/parallel/test-child-process-env.js',
+  'test/parallel/test-child-process-exec-buffer.js',
+  'test/parallel/test-child-process-exec-cwd.js',
+  'test/parallel/test-child-process-exec-env.js',
+  'test/parallel/test-child-process-exec-error.js',
+  'test/parallel/test-child-process-exit-code.js',
+  'test/parallel/test-child-process-fork3.js',
+  'test/parallel/test-child-process-fork-and-spawn.js',
+  'test/parallel/test-child-process-fork-close.js',
+  'test/parallel/test-child-process-fork-dgram.js',
+  'test/parallel/test-child-process-fork-exec-argv.js',
+  'test/parallel/test-child-process-fork-exec-path.js',
+  'test/parallel/test-child-process-fork.js',
+  'test/parallel/test-child-process-fork-net2.js',
+  'test/parallel/test-child-process-fork-net.js',
+  'test/parallel/test-child-process-fork-ref2.js',
+  'test/parallel/test-child-process-fork-ref.js',
+  'test/parallel/test-child-process-internal.js',
+  'test/parallel/test-child-process-ipc.js',
+  'test/parallel/test-child-process-kill.js',
+  'test/parallel/test-child-process-recv-handle.js',
+  'test/parallel/test-child-process-send-utf8.js',
+  'test/parallel/test-child-process-set-blocking.js',
+  'test/parallel/test-child-process-silent.js',
+  'test/parallel/test-child-process-spawn-error.js',
+  'test/parallel/test-child-process-spawnsync-env.js',
+  'test/parallel/test-child-process-spawnsync-input.js',
+  'test/parallel/test-child-process-spawnsync.js',
+  'test/parallel/test-child-process-spawnsync-timeout.js',
+  'test/parallel/test-child-process-spawn-typeerror.js',
+  'test/parallel/test-child-process-stdin-ipc.js',
+  'test/parallel/test-child-process-stdin.js',
+  'test/parallel/test-child-process-stdio-big-write-end.js',
+  'test/parallel/test-child-process-stdio-inherit.js',
+  'test/parallel/test-child-process-stdio.js',
+  'test/parallel/test-child-process-stdout-flush-exit.js',
+  'test/parallel/test-child-process-stdout-flush.js'
+];
+
+var parallelism = 4;
+var testsPerThread = Math.ceil(tests.length / parallelism);
+for (var i = 0; i < parallelism; ++i) {
+  var shareOfTests = tests.slice(i * testsPerThread, (i + 1) * testsPerThread);
+  var cur = Promise.resolve();
+  shareOfTests.forEach(function(testFile) {
+    cur = cur.then(function() {
+      return common.runTestInsideWorker(testFile);
+    });
+  });
+}

--- a/test/workers/test-crypto.js
+++ b/test/workers/test-crypto.js
@@ -1,0 +1,44 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var util = require('util');
+var Worker = require('worker');
+var common = require('../common');
+var checks = 0;
+// When using OpenSSL this test should put the locking_callback to good use
+var tests = [
+  'test/parallel/test-crypto-authenticated.js',
+  'test/parallel/test-crypto-binary-default.js',
+  'test/parallel/test-crypto-certificate.js',
+  'test/parallel/test-crypto-cipher-decipher.js',
+  'test/parallel/test-crypto-dh.js',
+  'test/parallel/test-crypto-dh-odd-key.js',
+  'test/parallel/test-crypto-domain.js',
+  'test/parallel/test-crypto-domains.js',
+  'test/parallel/test-crypto-ecb.js',
+  'test/parallel/test-crypto-from-binary.js',
+  'test/parallel/test-crypto-hash.js',
+  'test/parallel/test-crypto-hash-stream-pipe.js',
+  'test/parallel/test-crypto-hmac.js',
+  'test/parallel/test-crypto.js',
+  'test/parallel/test-crypto-padding-aes256.js',
+  'test/parallel/test-crypto-padding.js',
+  'test/parallel/test-crypto-pbkdf2.js',
+  'test/parallel/test-crypto-random.js',
+  'test/parallel/test-crypto-rsa-dsa.js',
+  'test/parallel/test-crypto-sign-verify.js',
+  'test/parallel/test-crypto-stream.js'
+];
+
+var parallelism = 4;
+var testsPerThread = Math.ceil(tests.length / parallelism);
+for (var i = 0; i < parallelism; ++i) {
+  var shareOfTests = tests.slice(i * testsPerThread, (i + 1) * testsPerThread);
+  var cur = Promise.resolve();
+  shareOfTests.forEach(function(testFile) {
+    cur = cur.then(function() {
+      return common.runTestInsideWorker(testFile);
+    });
+  });
+}

--- a/test/workers/test-domain.js
+++ b/test/workers/test-domain.js
@@ -1,0 +1,38 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var util = require('util');
+var Worker = require('worker');
+var common = require('../common');
+var checks = 0;
+
+var tests = [
+  'test/parallel/test-domain-abort-on-uncaught.js',
+  'test/parallel/test-domain-crypto.js',
+  'test/parallel/test-domain-enter-exit.js',
+  'test/parallel/test-domain-exit-dispose-again.js',
+  'test/parallel/test-domain-exit-dispose.js',
+  'test/parallel/test-domain-from-timer.js',
+  'test/parallel/test-domain-http-server.js',
+  'test/parallel/test-domain-implicit-fs.js',
+  'test/parallel/test-domain.js',
+  'test/parallel/test-domain-multi.js',
+  'test/parallel/test-domain-nested.js',
+  'test/parallel/test-domain-nested-throw.js',
+  'test/parallel/test-domain-safe-exit.js',
+  'test/parallel/test-domain-stack.js',
+  'test/parallel/test-domain-timers.js'
+];
+
+var parallelism = 4;
+var testsPerThread = Math.ceil(tests.length / parallelism);
+for (var i = 0; i < parallelism; ++i) {
+  var shareOfTests = tests.slice(i * testsPerThread, (i + 1) * testsPerThread);
+  var cur = Promise.resolve();
+  shareOfTests.forEach(function(testFile) {
+    cur = cur.then(function() {
+      return common.runTestInsideWorker(testFile);
+    });
+  });
+}

--- a/test/workers/test-error-event.js
+++ b/test/workers/test-error-event.js
@@ -1,0 +1,34 @@
+// Flags: --experimental-workers
+'use strict';
+
+// Uncaught exceptions inside worker bubble to the parent thread's worker
+// object's 'error' event.
+
+var assert = require('assert');
+var Worker = require('worker');
+var checks = 0;
+
+if (process.isMainThread) {
+  var aWorker = new Worker(__filename, {keepAlive: false});
+
+  aWorker.on('error', function(e) {
+    assert(e instanceof ReferenceError);
+    assert.equal('ReferenceError: undefinedReference is not defined',
+                 e.toString());
+    checks++;
+  });
+
+  aWorker.on('message', function(data) {
+    assert.deepEqual({hello: 'world'}, data);
+    checks++;
+  });
+
+  process.on('beforeExit', function() {
+    assert.equal(2, checks);
+  });
+} else {
+  setTimeout(function() {
+    Worker.postMessage({hello: 'world'});
+  }, 5);
+  undefinedReference;
+}

--- a/test/workers/test-eval.js
+++ b/test/workers/test-eval.js
@@ -1,0 +1,20 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var Worker = require('worker');
+
+var gotMessage = false;
+var a = new Worker('require("worker").postMessage(null);', {
+  keepAlive: false,
+  eval: true
+});
+
+a.on('message', function(data) {
+  assert.strictEqual(data, null);
+  gotMessage = true;
+});
+
+process.on('beforeExit', function() {
+  assert(gotMessage);
+});

--- a/test/workers/test-fs.js
+++ b/test/workers/test-fs.js
@@ -1,0 +1,85 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var util = require('util');
+var Worker = require('worker');
+var common = require('../common');
+var checks = 0;
+
+// FIXME(petkaantonov): Commented out tests can only be run when
+// multiple tmp directories are created which is done by tools/run.py
+// when running the tests in parallel using multiple processes.
+var tests = [
+  'test/parallel/test-domain-implicit-fs.js',
+  'test/parallel/test-fs-access.js',
+  'test/parallel/test-fs-append-file.js',
+  'test/parallel/test-fs-append-file-sync.js',
+  'test/parallel/test-fs-chmod.js',
+  'test/parallel/test-fs-empty-readStream.js',
+  'test/parallel/test-fs-error-messages.js',
+  'test/parallel/test-fs-exists.js',
+  'test/parallel/test-fs-fsync.js',
+  'test/parallel/test-fs-long-path.js',
+  'test/parallel/test-fs-make-callback.js',
+  'test/parallel/test-fs-mkdir.js',
+  'test/parallel/test-fs-non-number-arguments-throw.js',
+  'test/parallel/test-fs-null-bytes.js',
+  'test/parallel/test-fs-open-flags.js',
+  'test/parallel/test-fs-open.js',
+  'test/parallel/test-fs-read-buffer.js',
+  'test/parallel/test-fs-readfile-empty.js',
+  'test/parallel/test-fs-readfile-error.js',
+  'test/parallel/test-fs-readfile-pipe.js',
+  'test/parallel/test-fs-read-file-sync-hostname.js',
+  'test/parallel/test-fs-read-file-sync.js',
+  'test/parallel/test-fs-readfile-unlink.js',
+  'test/parallel/test-fs-readfile-zero-byte-liar.js',
+  'test/parallel/test-fs-read.js',
+  'test/parallel/test-fs-read-stream-err.js',
+  'test/parallel/test-fs-read-stream-fd.js',
+  'test/parallel/test-fs-read-stream-fd-leak.js',
+  'test/parallel/test-fs-read-stream-inherit.js',
+  'test/parallel/test-fs-read-stream.js',
+  'test/parallel/test-fs-read-stream-resume.js',
+  // Workers cannot chdir.
+  // 'test/parallel/test-fs-realpath.js',
+  'test/parallel/test-fs-sir-writes-alot.js',
+  'test/parallel/test-fs-stat.js',
+  'test/parallel/test-fs-stream-double-close.js',
+  'test/parallel/test-fs-symlink-dir-junction.js',
+  'test/parallel/test-fs-symlink-dir-junction-relative.js',
+  'test/parallel/test-fs-symlink.js',
+  'test/parallel/test-fs-sync-fd-leak.js',
+  'test/parallel/test-fs-truncate-fd.js',
+  'test/parallel/test-fs-truncate-GH-6233.js',
+  'test/parallel/test-fs-truncate.js',
+  'test/parallel/test-fs-utimes.js',
+  'test/parallel/test-fs-write-buffer.js',
+  'test/parallel/test-fs-write-file-buffer.js',
+  'test/parallel/test-fs-write-file.js',
+  // Workers cannot change umask.
+  // 'test/parallel/test-fs-write-file-sync.js',
+  'test/parallel/test-fs-write.js',
+  'test/parallel/test-fs-write-stream-change-open.js',
+  'test/parallel/test-fs-write-stream-end.js',
+  'test/parallel/test-fs-write-stream-err.js',
+  'test/parallel/test-fs-write-stream.js',
+  'test/parallel/test-fs-write-string-coerce.js',
+  'test/parallel/test-fs-write-sync.js'
+];
+
+var parallelism = 4;
+var testsPerThread = Math.ceil(tests.length / parallelism);
+for (var i = 0; i < parallelism; ++i) {
+  (function(i) {
+    var shareOfTests =
+        tests.slice(i * testsPerThread, (i + 1) * testsPerThread);
+    var cur = Promise.resolve();
+    shareOfTests.forEach(function(testFile) {
+      cur = cur.then(function() {
+        return common.runTestInsideWorker(testFile, {testThreadId: '' + i});
+      });
+    });
+  })(i);
+}

--- a/test/workers/test-keep-alive.js
+++ b/test/workers/test-keep-alive.js
@@ -1,0 +1,26 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var Worker = require('worker');
+var checks = 0;
+
+if (process.isMainThread) {
+  var aWorker = new Worker(__filename);
+  aWorker.on('exit', function() {
+    if (checks === 2)
+      checks++;
+  });
+  aWorker.on('message', function() {
+    checks++;
+    setTimeout(function() {
+      checks++;
+      aWorker.terminate();
+    }, 5);
+  });
+  process.on('beforeExit', function() {
+    assert.equal(3, checks);
+  });
+} else {
+  Worker.postMessage();
+}

--- a/test/workers/test-memory-leak.js
+++ b/test/workers/test-memory-leak.js
@@ -1,0 +1,30 @@
+// Flags: --experimental-workers --max-semi-space-size=1 --max-old-space-size=16
+'use strict';
+
+// Just something to run with valgrind, not real test
+
+if (process.isMainThread) {
+  var assert = require('assert');
+  var util = require('util');
+  var Worker = require('worker');
+  var common = require('../common');
+  var checks = 0;
+
+  var rss = function() {
+    return process.memoryUsage().rss;
+  };
+
+  var l = 1;
+  var cur = Promise.resolve();
+  while (l--) {
+    cur = cur.then(function() {
+      var promises = [];
+      var k = 4;
+      while (k--)
+        promises.push(common.runTestInsideWorker(__filename));
+      return Promise.all(promises);
+    }).then(function() {
+      console.log(rss());
+    });
+  }
+}

--- a/test/workers/test-messaging-intense.js
+++ b/test/workers/test-messaging-intense.js
@@ -1,0 +1,45 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var Worker = require('worker');
+
+// Test that both primary and backup queue work
+if (process.isMainThread) {
+  const TO_SEND = 4096;
+  const POST_MORE_THRESHOLD = 1024;
+  // 2 is the number of messages posted back by the worker for each message
+  // it receives
+  const EXPECTED_TO_RECEIVE = ((TO_SEND / POST_MORE_THRESHOLD * 2) - 1) *
+                              POST_MORE_THRESHOLD * 2 + TO_SEND * 2;
+
+  var messagesReceived = 0;
+  var worker = new Worker(__filename);
+  worker.on('message', function() {
+    messagesReceived++;
+    if ((messagesReceived % POST_MORE_THRESHOLD) === 0 &&
+         messagesReceived < (TO_SEND * 2)) {
+      var l = POST_MORE_THRESHOLD;
+      while (l--)
+        worker.postMessage();
+    }
+
+    if (messagesReceived == EXPECTED_TO_RECEIVE)
+      worker.terminate();
+  });
+
+  var l = TO_SEND;
+  while (l--)
+    worker.postMessage();
+
+  process.on('beforeExit', function() {
+    assert.equal(EXPECTED_TO_RECEIVE, messagesReceived);
+  });
+} else {
+  Worker.on('message', function() {
+    Worker.postMessage();
+    process.nextTick(function() {
+      Worker.postMessage();
+    });
+  });
+}

--- a/test/workers/test-process.js
+++ b/test/workers/test-process.js
@@ -1,0 +1,43 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var util = require('util');
+var Worker = require('worker');
+var common = require('../common');
+var checks = 0;
+
+var tests = [
+  'test/parallel/test-process-argv-0.js',
+  'test/parallel/test-process-before-exit.js',
+  'test/parallel/test-process-binding.js',
+  'test/parallel/test-process-config.js',
+  // Only main thread can mutate process environment.
+  // 'test/parallel/test-process-env.js',
+  'test/parallel/test-process-exec-argv.js',
+  'test/parallel/test-process-exit-code.js',
+  'test/parallel/test-process-exit-from-before-exit.js',
+  'test/parallel/test-process-exit.js',
+  'test/parallel/test-process-exit-recursive.js',
+  'test/parallel/test-process-getgroups.js',
+  'test/parallel/test-process-hrtime.js',
+  'test/parallel/test-process-kill-null.js',
+  'test/parallel/test-process-kill-pid.js',
+  'test/parallel/test-process-next-tick.js',
+  'test/parallel/test-process-raw-debug.js',
+  'test/parallel/test-process-remove-all-signal-listeners.js',
+  'test/parallel/test-process-versions.js',
+  'test/parallel/test-process-wrap.js'
+];
+
+var parallelism = 4;
+var testsPerThread = Math.ceil(tests.length / parallelism);
+for (var i = 0; i < parallelism; ++i) {
+  var shareOfTests = tests.slice(i * testsPerThread, (i + 1) * testsPerThread);
+  var cur = Promise.resolve();
+  shareOfTests.forEach(function(testFile) {
+    cur = cur.then(function() {
+      return common.runTestInsideWorker(testFile);
+    });
+  });
+}

--- a/test/workers/test-stream.js
+++ b/test/workers/test-stream.js
@@ -1,0 +1,67 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var util = require('util');
+var Worker = require('worker');
+var common = require('../common');
+var checks = 0;
+
+var tests = [
+  'test/parallel/test-stream2-base64-single-char-read-end.js',
+  'test/parallel/test-stream2-compatibility.js',
+  'test/parallel/test-stream2-finish-pipe.js',
+  'test/parallel/test-stream2-large-read-stall.js',
+  'test/parallel/test-stream2-objects.js',
+  'test/parallel/test-stream2-pipe-error-handling.js',
+  'test/parallel/test-stream2-pipe-error-once-listener.js',
+  'test/parallel/test-stream2-push.js',
+  'test/parallel/test-stream2-readable-empty-buffer-no-eof.js',
+  'test/parallel/test-stream2-readable-from-list.js',
+  'test/parallel/test-stream2-readable-legacy-drain.js',
+  'test/parallel/test-stream2-readable-non-empty-end.js',
+  'test/parallel/test-stream2-readable-wrap-empty.js',
+  'test/parallel/test-stream2-readable-wrap.js',
+  'test/parallel/test-stream2-read-sync-stack.js',
+  'test/parallel/test-stream2-set-encoding.js',
+  'test/parallel/test-stream2-transform.js',
+  'test/parallel/test-stream2-unpipe-drain.js',
+  'test/parallel/test-stream2-unpipe-leak.js',
+  'test/parallel/test-stream2-writable.js',
+  'test/parallel/test-stream3-pause-then-read.js',
+  'test/parallel/test-stream-big-packet.js',
+  'test/parallel/test-stream-big-push.js',
+  'test/parallel/test-stream-duplex.js',
+  'test/parallel/test-stream-end-paused.js',
+  'test/parallel/test-stream-ispaused.js',
+  'test/parallel/test-stream-pipe-after-end.js',
+  'test/parallel/test-stream-pipe-cleanup.js',
+  'test/parallel/test-stream-pipe-error-handling.js',
+  'test/parallel/test-stream-pipe-event.js',
+  'test/parallel/test-stream-push-order.js',
+  'test/parallel/test-stream-push-strings.js',
+  'test/parallel/test-stream-readable-constructor-set-methods.js',
+  'test/parallel/test-stream-readable-event.js',
+  'test/parallel/test-stream-readable-flow-recursion.js',
+  'test/parallel/test-stream-transform-constructor-set-methods.js',
+  'test/parallel/test-stream-transform-objectmode-falsey-value.js',
+  'test/parallel/test-stream-transform-split-objectmode.js',
+  'test/parallel/test-stream-unshift-empty-chunk.js',
+  'test/parallel/test-stream-unshift-read-race.js',
+  'test/parallel/test-stream-writable-change-default-encoding.js',
+  'test/parallel/test-stream-writable-constructor-set-methods.js',
+  'test/parallel/test-stream-writable-decoded-encoding.js',
+  'test/parallel/test-stream-writev.js'
+];
+
+var parallelism = 4;
+var testsPerThread = Math.ceil(tests.length / parallelism);
+for (var i = 0; i < parallelism; ++i) {
+  var shareOfTests = tests.slice(i * testsPerThread, (i + 1) * testsPerThread);
+  var cur = Promise.resolve();
+  shareOfTests.forEach(function(testFile) {
+    cur = cur.then(function() {
+      return common.runTestInsideWorker(testFile);
+    });
+  });
+}

--- a/test/workers/test-termination-2.js
+++ b/test/workers/test-termination-2.js
@@ -1,0 +1,22 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var Worker = require('worker');
+var checks = 0;
+
+if (process.isMainThread) {
+  var aWorker = new Worker(__filename);
+  aWorker.terminate(function() {
+    checks++;
+  });
+  aWorker.on('message', function() {
+    checks++;
+  });
+  process.on('beforeExit', function() {
+    assert.equal(1, checks);
+  });
+} else {
+  while (true)
+    Worker.postMessage({hello: 'world'});
+}

--- a/test/workers/test-termination-3.js
+++ b/test/workers/test-termination-3.js
@@ -1,0 +1,33 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var Worker = require('worker');
+var checks = 0;
+
+if (process.isMainThread) {
+  var aWorker = new Worker(__filename);
+  var gotMessage = false;
+  aWorker.on('message', function() {
+    if (gotMessage) return;
+    gotMessage = true;
+    checks++;
+    aWorker.postMessage();
+    aWorker.postMessage();
+    aWorker.postMessage();
+    aWorker.postMessage();
+    aWorker.terminate(function() {
+      checks++;
+    });
+  });
+  process.on('beforeExit', function() {
+    assert.equal(2, checks);
+  });
+} else {
+  Worker.on('message', function() {
+    while (true)
+      Worker.postMessage({hello: 'world'});
+  });
+
+  Worker.postMessage();
+}

--- a/test/workers/test-termination-exit-2.js
+++ b/test/workers/test-termination-exit-2.js
@@ -1,0 +1,36 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var Worker = require('worker');
+var checks = 0;
+
+if (process.isMainThread) {
+  var aWorker = new Worker(__filename, {keepAlive: false});
+  aWorker.on('exit', function(code) {
+    assert.equal(1337, code);
+    checks++;
+  });
+  aWorker.on('message', function(data) {
+    assert.equal(data, 0);
+    checks++;
+  });
+  process.on('beforeExit', function() {
+    assert.equal(2, checks);
+  });
+} else {
+  var emits = 0;
+  process.on('beforeExit', function() {
+    setInterval(function() {
+      Worker.postMessage({hello: 'world'});
+    }, 5000);
+    setImmediate(function f() {
+      Worker.postMessage({hello: 'world'});
+      setImmediate(f);
+    });
+    process.exit(1337);
+  });
+  process.on('exit', function() {
+    Worker.postMessage(emits++);
+  });
+}

--- a/test/workers/test-termination-exit.js
+++ b/test/workers/test-termination-exit.js
@@ -1,0 +1,33 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var Worker = require('worker');
+var checks = 0;
+
+if (process.isMainThread) {
+  var aWorker = new Worker(__filename);
+  aWorker.on('exit', function(code) {
+    assert.equal(1337, code);
+    checks++;
+  });
+  aWorker.on('message', function() {
+    assert.fail();
+  });
+  process.on('beforeExit', function() {
+    assert.equal(1, checks);
+  });
+} else {
+  setInterval(function() {
+    Worker.postMessage({hello: 'world'});
+  }, 5000);
+  setImmediate(function f() {
+    Worker.postMessage({hello: 'world'});
+    setImmediate(f);
+  });
+  (function() {
+    [1337, 2, 3].map(function(value) {
+      process.exit(value);
+    });
+  })();
+}

--- a/test/workers/test-termination-grand-parent.js
+++ b/test/workers/test-termination-grand-parent.js
@@ -1,0 +1,56 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var Worker = require('worker');
+var ids = [];
+var checks = 0;
+
+
+if (process.isMainThread) {
+  var aWorker = new Worker(__filename);
+  aWorker.postMessage({
+    init: true,
+    subWorker: false
+  });
+  aWorker.on('message', function(data) {
+    ids.push(data.id);
+    if (ids.length === 4) {
+      // Terminating the main worker should terminate its 4 sub-workers
+      aWorker.terminate();
+    }
+  });
+  process.on('beforeExit', function() {
+    assert.deepEqual([0, 1, 2, 3].sort(), ids.sort());
+  });
+} else {
+  Worker.on('message', function(data) {
+    if (data.init) {
+      if (data.subWorker) {
+        subWorker(data.id);
+      } else {
+        mainWorker();
+      }
+    }
+  });
+
+  var mainWorker = function() {
+    var l = 4;
+    while (l--) {
+      var worker = new Worker(__filename);
+      worker.postMessage({
+        init: true,
+        subWorker: true,
+        id: l
+      });
+      worker.on('message', function(payload) {
+        Worker.postMessage(payload);
+      });
+    }
+  };
+
+  var subWorker = function(id) {
+    Worker.postMessage({id: id});
+    while (true);
+  };
+}

--- a/test/workers/test-termination-owner.js
+++ b/test/workers/test-termination-owner.js
@@ -1,0 +1,32 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var Worker = require('worker');
+
+// Test that termination of a worker that is in the middle of processing
+// messages from its sub-worker works.
+
+if (process.isMainThread) {
+  var worker = new Worker(__filename);
+  worker.postMessage({main: true});
+  worker.on('message', function() {
+    worker.terminate();
+  });
+} else {
+  Worker.on('message', function(data) {
+    if (data.main) {
+      var messagesReceived = 0;
+      var subworker = new Worker(__filename);
+      subworker.postMessage({main: false});
+      subworker.on('message', function() {
+        messagesReceived++;
+
+        if (messagesReceived === 512)
+          Worker.postMessage();
+      });
+    } else {
+      while (true) Worker.postMessage();
+    }
+  });
+}

--- a/test/workers/test-termination-races.js
+++ b/test/workers/test-termination-races.js
@@ -1,0 +1,120 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var Worker = require('worker');
+var checks = 0;
+var MESSAGES_PER_GRAND_CHILD_WORKER = 20;
+
+
+if (process.isMainThread) {
+  var l = 4;
+  var workers = {};
+  while (l--) {
+    var worker = new Worker(__filename);
+    worker.on('message', function(worker) {
+      return function(data) {
+        if (workers[data.id]) return;
+        checks++;
+        worker.terminate();
+        workers[data.id] = true;
+      };
+    }(worker));
+    worker.postMessage({id: l});
+  }
+  process.on('beforeExit', function() {
+    assert.equal(4, checks);
+  });
+} else {
+  Worker.on('message', function(data) {
+    if (data.id <= 3) {
+      runImmediateChildWorker(data);
+    } else {
+      runGrandChildWorker(data);
+    }
+  });
+
+  var runImmediateChildWorker = function(mainData) {
+    var messages = {};
+    var l = 4;
+    while (l--) {
+      var subWorkerId = mainData.id * 4 + 4 + l;
+      messages[subWorkerId] = 0;
+      var worker = new Worker(__filename);
+      worker.on('message', function(data) {
+        var count = ++messages[data.id];
+        if (count === MESSAGES_PER_GRAND_CHILD_WORKER) {
+          Worker.postMessage({id: mainData.id});
+        }
+      });
+      worker.postMessage({id: subWorkerId});
+    }
+  };
+
+  var runGrandChildWorker = function(data) {
+    var l = MESSAGES_PER_GRAND_CHILD_WORKER;
+    process.stdout;
+    process.stderr;
+    process.stdin;
+    try {require('assert');} catch(e) {}
+    try {require('buffer');} catch(e) {}
+    try {require('child_process');} catch(e) {}
+    try {require('cluster');} catch(e) {}
+    try {require('console');} catch(e) {}
+    try {require('constants');} catch(e) {}
+    try {require('crypto');} catch(e) {}
+    try {require('_debug_agent');} catch(e) {}
+    try {require('_debugger');} catch(e) {}
+    try {require('dgram');} catch(e) {}
+    try {require('dns');} catch(e) {}
+    try {require('domain');} catch(e) {}
+    try {require('events');} catch(e) {}
+    try {require('freelist');} catch(e) {}
+    try {require('fs');} catch(e) {}
+    try {require('_http_agent');} catch(e) {}
+    try {require('_http_client');} catch(e) {}
+    try {require('_http_common');} catch(e) {}
+    try {require('_http_incoming');} catch(e) {}
+    try {require('http');} catch(e) {}
+    try {require('_http_outgoing');} catch(e) {}
+    try {require('_http_server');} catch(e) {}
+    try {require('https');} catch(e) {}
+    try {require('_linklist');} catch(e) {}
+    try {require('module');} catch(e) {}
+    try {require('net');} catch(e) {}
+    try {require('os');} catch(e) {}
+    try {require('path');} catch(e) {}
+    try {require('process');} catch(e) {}
+    try {require('punycode');} catch(e) {}
+    try {require('querystring');} catch(e) {}
+    try {require('readline');} catch(e) {}
+    try {require('repl');} catch(e) {}
+    try {require('smalloc');} catch(e) {}
+    try {require('_stream_duplex');} catch(e) {}
+    try {require('stream');} catch(e) {}
+    try {require('_stream_passthrough');} catch(e) {}
+    try {require('_stream_readable');} catch(e) {}
+    try {require('_stream_transform');} catch(e) {}
+    try {require('_stream_wrap');} catch(e) {}
+    try {require('_stream_writable');} catch(e) {}
+    try {require('string_decoder');} catch(e) {}
+    try {require('timers');} catch(e) {}
+    try {require('_tls_common');} catch(e) {}
+    try {require('tls');} catch(e) {}
+    try {require('_tls_legacy');} catch(e) {}
+    try {require('_tls_wrap');} catch(e) {}
+    try {require('tty');} catch(e) {}
+    try {require('url');} catch(e) {}
+    try {require('util');} catch(e) {}
+    try {require('v8');} catch(e) {}
+    try {require('vm');} catch(e) {}
+    try {require('worker');} catch(e) {}
+    try {require('zlib');} catch(e) {}
+    while (l--) {
+      Worker.postMessage({
+        id: data.id
+      });
+    }
+  };
+
+}

--- a/test/workers/test-termination.js
+++ b/test/workers/test-termination.js
@@ -1,0 +1,27 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var Worker = require('worker');
+var checks = 0;
+
+if (process.isMainThread) {
+  var aWorker = new Worker(__filename);
+  aWorker.terminate(function() {
+    checks++;
+  });
+  aWorker.on('message', function() {
+    assert.fail();
+  });
+  process.on('beforeExit', function() {
+    assert.equal(1, checks);
+  });
+} else {
+  setInterval(function() {
+    Worker.postMessage({hello: 'world'});
+  }, 5000);
+  setImmediate(function f() {
+    Worker.postMessage({hello: 'world'});
+    setImmediate(f);
+  });
+}

--- a/test/workers/test-unref-2.js
+++ b/test/workers/test-unref-2.js
@@ -1,0 +1,35 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var Worker = require('worker');
+var checks = 0;
+
+if (process.isMainThread) {
+  var timer = setInterval(function() {}, 1000);;
+  var aWorker = new Worker(__filename);
+  aWorker.on('exit', function() {
+    checks++;
+  });
+  aWorker.on('message', function() {
+    checks++;
+    setTimeout(function() {
+      checks++;
+      aWorker.terminate(function() {
+        checks++;
+        clearInterval(timer);
+      });
+    }, 5);
+  });
+  process.on('beforeExit', function() {
+    assert.equal(4, checks);
+  });
+  aWorker.unref();
+  aWorker.postMessage();
+} else {
+  Worker.on('message', function() {
+    setTimeout(function() {
+      Worker.postMessage();
+    }, 1);
+  });
+}

--- a/test/workers/test-unref.js
+++ b/test/workers/test-unref.js
@@ -1,0 +1,28 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var Worker = require('worker');
+var checks = 0;
+
+if (process.isMainThread) {
+  var aWorker = new Worker(__filename);
+  aWorker.on('exit', function() {
+    checks++;
+  });
+  aWorker.on('message', function() {
+    checks++;
+    setTimeout(function() {
+      checks++;
+      aWorker.terminate();
+    }, 5);
+  });
+  process.on('beforeExit', function() {
+    assert.equal(0, checks);
+  });
+  aWorker.unref();
+} else {
+  setInterval(function() {
+    Worker.postMessage();
+  }, 5);
+}

--- a/test/workers/test-vm.js
+++ b/test/workers/test-vm.js
@@ -1,0 +1,46 @@
+// Flags: --experimental-workers --harmony_proxies
+'use strict';
+
+var assert = require('assert');
+var util = require('util');
+var Worker = require('worker');
+var common = require('../common');
+var checks = 0;
+
+var tests = [
+  'test/parallel/test-vm-basic.js',
+  'test/parallel/test-vm-context-async-script.js',
+  'test/parallel/test-vm-context.js',
+  'test/parallel/test-vm-context-property-forwarding.js',
+  'test/parallel/test-vm-create-and-run-in-context.js',
+  'test/parallel/test-vm-create-context-accessors.js',
+  'test/parallel/test-vm-create-context-arg.js',
+  'test/parallel/test-vm-create-context-circular-reference.js',
+  'test/parallel/test-vm-cross-context.js',
+  'test/parallel/test-vm-debug-context.js',
+  'test/parallel/test-vm-function-declaration.js',
+  'test/parallel/test-vm-global-define-property.js',
+  'test/parallel/test-vm-global-identity.js',
+  'test/parallel/test-vm-harmony-proxies.js',
+  'test/parallel/test-vm-harmony-symbols.js',
+  'test/parallel/test-vm-is-context.js',
+  'test/parallel/test-vm-new-script-new-context.js',
+  'test/parallel/test-vm-new-script-this-context.js',
+  // Needs --expose-gc but exposing it for the process causes other tests
+  // to fail
+  // 'test/parallel/test-vm-run-in-new-context.js',
+  'test/parallel/test-vm-static-this.js',
+  'test/parallel/test-vm-timeout.js'
+];
+
+var parallelism = 4;
+var testsPerThread = Math.ceil(tests.length / parallelism);
+for (var i = 0; i < parallelism; ++i) {
+  var shareOfTests = tests.slice(i * testsPerThread, (i + 1) * testsPerThread);
+  var cur = Promise.resolve();
+  shareOfTests.forEach(function(testFile) {
+    cur = cur.then(function() {
+      return common.runTestInsideWorker(testFile);
+    });
+  });
+}

--- a/test/workers/test-zlib.js
+++ b/test/workers/test-zlib.js
@@ -1,0 +1,36 @@
+// Flags: --experimental-workers
+'use strict';
+
+var assert = require('assert');
+var util = require('util');
+var Worker = require('worker');
+var common = require('../common');
+var checks = 0;
+var tests = [
+  'test/parallel/test-zlib-close-after-write.js',
+  'test/parallel/test-zlib-convenience-methods.js',
+  'test/parallel/test-zlib-dictionary-fail.js',
+  'test/parallel/test-zlib-dictionary.js',
+  'test/parallel/test-zlib-flush.js',
+  'test/parallel/test-zlib-from-gzip.js',
+  'test/parallel/test-zlib-from-string.js',
+  'test/parallel/test-zlib-invalid-input.js',
+  'test/parallel/test-zlib.js',
+  'test/parallel/test-zlib-params.js',
+  'test/parallel/test-zlib-random-byte-pipes.js',
+  'test/parallel/test-zlib-write-after-close.js',
+  'test/parallel/test-zlib-write-after-flush.js',
+  'test/parallel/test-zlib-zero-byte.js'
+];
+
+var parallelism = 4;
+var testsPerThread = Math.ceil(tests.length / parallelism);
+for (var i = 0; i < parallelism; ++i) {
+  var shareOfTests = tests.slice(i * testsPerThread, (i + 1) * testsPerThread);
+  var cur = Promise.resolve();
+  shareOfTests.forEach(function(testFile) {
+    cur = cur.then(function() {
+      return common.runTestInsideWorker(testFile);
+    });
+  });
+}

--- a/test/workers/testcfg.py
+++ b/test/workers/testcfg.py
@@ -1,0 +1,6 @@
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+import testpy
+
+def GetConfiguration(context, root):
+  return testpy.SimpleTestConfiguration(context, root, 'workers')

--- a/tools/test.py
+++ b/tools/test.py
@@ -1393,6 +1393,7 @@ BUILT_IN_TESTS = [
   'addons',
   'gc',
   'debugger',
+  'workers'
 ]
 
 

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -60,6 +60,7 @@ if /i "%1"=="test-message"  set test_args=%test_args% message&goto arg-ok
 if /i "%1"=="test-gc"       set test_args=%test_args% gc&set buildnodeweak=1&goto arg-ok
 if /i "%1"=="test-internet" set test_args=%test_args% internet&goto arg-ok
 if /i "%1"=="test-pummel"   set test_args=%test_args% pummel&goto arg-ok
+if /i "%1"=="test-workers"  set test_args=%test_args% workers&goto arg-ok
 if /i "%1"=="test-all"      set test_args=%test_args% sequential parallel message gc internet pummel&set buildnodeweak=1&set jslint=1&goto arg-ok
 if /i "%1"=="jslint"        set jslint=1&goto arg-ok
 @rem Include small-icu support with MSI installer


### PR DESCRIPTION
Changed the message queue to be unbounded to simplify message passing logic and avoid a lock.

This has been tested against the unit tests, workers test, and the fifo properties/memory safety have been tested with valgrind under contention.

git botched the diff on producer-consumer-queue.h, but the entire thing has been changed.
